### PR TITLE
CI: don't re-run tests on the merge-to-main push

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: Tests
 
 on:
   push:
+    branches-ignore: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
The \`push\` trigger had no branch filter, so merging a PR fired a
redundant second test run on the resulting merge commit -- the check
had already passed on the PR itself before the merge button was even
enabled. Scopes \`push\` to everything except \`main\`; \`pull_request\`
still gates every merge exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)