### PR TITLE
Balance line wrapping in commemoration/feast/service-note lists

### DIFF
--- a/orthocal/static/main.css
+++ b/orthocal/static/main.css
@@ -195,6 +195,7 @@ label input[type="radio"] {
     margin: 0;
     padding: 0;
 	list-style-type: none;
+	text-wrap: balance;
 }
 .service-notes h2, .feasts h2, .commemorations h2 {
     margin-bottom: 0em;


### PR DESCRIPTION
## Summary

- Individual saint/feast/service-note entries were occasionally wrapping mid-title at an awkward point (e.g. leaving a lone orphaned word on the last line), since these `<li>` elements are `display: inline` and the browser has no way to distinguish "space within one title" from "space between two items."
- Adds `text-wrap: balance` to `.service-notes ul, .commemorations ul, .feasts ul`, the same technique already used on this site's headings (`h1, h2, h3, h4`), so line breaks get redistributed evenly rather than leaving a short widow/orphan line.
- Considered a stronger fix (`display: inline-block; white-space: nowrap`, making each title fully atomic) but the user preferred allowing mid-title breaks in exchange for balanced wrapping, so `text-wrap: balance` alone was kept.

## Test plan

- [x] Verified live against the dev server (bind-mounted `orthocal/static/main.css`, no rebuild needed) that the updated CSS renders as expected
- [ ] No further browser/visual regression testing done in this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)