### PR TITLE
Link commemorations to their full stories below the readings

### DIFF
--- a/calendarium/liturgics/day.py
+++ b/calendarium/liturgics/day.py
@@ -294,6 +294,11 @@ class Day:
             # self.feasts; story-only, excluded here.
 
         self.saints = []
+        # Parallel to self.saints, but pairs each title with the story's id
+        # (or None) so the readings template can link a commemoration to its
+        # full story further down the page, without changing self.saints
+        # itself -- it's consumed as plain strings elsewhere (ical.py, RSS).
+        self.saint_links = []
         self.spoken_saints = []
         self.minimal_saints = []
         for dcs in day_native_by_day.values():
@@ -304,11 +309,13 @@ class Day:
             # feast-level-facts preference for this tradition.
             titles = [dc.title for dc in dcs]
             self.saints.extend(titles)
+            self.saint_links.extend((dc.title, dc.id if dc.story else None) for dc in dcs)
             self.spoken_saints.extend(dc.title for dc in dcs if _speech_worthy(dc))
             if titles:
                 self.minimal_saints.append('; '.join(titles))
 
         self.saints.extend(dc.title for dc in additive)
+        self.saint_links.extend((dc.title, dc.id if dc.story else None) for dc in additive)
         self.spoken_saints.extend(dc.title for dc in additive if _speech_worthy(dc))
 
         # spoken_saints excludes only the story-less tradition='greek' overlay

--- a/calendarium/templates/readings.html
+++ b/calendarium/templates/readings.html
@@ -72,8 +72,8 @@
 		<section class="commemorations">
 			<h2>Commemorations</h2>
 			<ul>
-				{% for saint in day.saints %}
-				<li>{{ saint|widont }}</li>
+				{% for saint, story_id in day.saint_links %}
+				<li>{% if story_id %}<a href="#commemoration-{{ story_id }}">{{ saint|widont }}</a>{% else %}{{ saint|widont }}{% endif %}</li>
 				{% endfor %}
 			</ul>
 		</section>
@@ -107,7 +107,7 @@
 		<h1>Commemorations</h1>
 
 			{% for reading in day.stories %}
-			<article class="passage">
+			<article class="passage" id="commemoration-{{ reading.id }}">
 				<h2>{{ reading.title|widont }}</h2>
 
 				{{ reading.story|safe }}

--- a/orthocal/static/main.css
+++ b/orthocal/static/main.css
@@ -253,6 +253,13 @@ table.month tr:first-child th {
     color: black;
 	padding: 0.5em;
 }
+.commemorations li a {
+	color: inherit;
+	text-decoration: none;
+}
+.commemorations li a:hover {
+	text-decoration: underline;
+}
 
 p.feast {
 	font-weight: bold;


### PR DESCRIPTION
## Summary

- Each saint/feast in the top-of-page commemorations list now links to its corresponding full story further down the page (in the section following the scripture readings), when one exists.
- `Day.saint_links` (new, in `calendarium/liturgics/day.py`) pairs each title with its `DayCommemoration` id (or `None`) in parallel with `self.saints` -- `self.saints` itself is untouched, since it's also consumed as plain strings elsewhere (`ical.py`, RSS feed description).
- Story-less commemorations (the antiochian.org bulk-harvested entries from the previous PR) render as plain text, same as before -- there's nothing to link to.
- Added `.commemorations li a` CSS so the new links inherit the existing red color/no-underline styling instead of the browser's default blue/underlined link style (the readings page doesn't use the `#content` wrapper that already had link styling elsewhere on the site).

## Test plan

- [x] Full test suite passes (120/120)
- [x] Verified live on the dev server: Jan 1 (both commemorations have stories and link correctly) and July 29 in Greek tradition (2 linked, 5 plain-text for story-less entries)
- [ ] No further cross-browser/visual check done in this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)