### PR TITLE
Enable log_language middleware to gauge real Accept-Language usage

### DIFF
--- a/orthocal/settings.py
+++ b/orthocal/settings.py
@@ -91,6 +91,7 @@ MIDDLEWARE = [
     'django.middleware.gzip.GZipMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
+    'orthocal.middleware.log_language',
     'django.middleware.common.CommonMiddleware',
     'orthocal.middleware.cache_control',
 ]


### PR DESCRIPTION
orthocal.middleware.log_language already existed (logs the resolved Accept-Language header at DEBUG level) but was never registered in MIDDLEWARE, so it never actually ran. Wiring it in so we can get a real, forward-looking answer on whether the Romanian/Serbian translations see any traffic, before deciding whether to keep them -- Cloud Run's default request logs don't capture request headers at all, and there's no existing signal to mine retroactively.