### PR TITLE
Consolidate 9 fragmented saint identities missed by the original refactor

### DIFF
--- a/calendarium/tests/data/january.json
+++ b/calendarium/tests/data/january.json
@@ -22,8 +22,7 @@
         "fast_exception": 11,
         "fast_exception_desc": "Fast Free",
         "saints": [
-            "St Gregory, Bishop of Nazianzus (374), father of St Gregory the Theologian",
-            "St Emilia (375), mother of Sts Macrina, Basil the Great and Gregory of Nyssa, Peter of Sebaste, and Theosevia"
+            "St Gregory, Bishop of Nazianzus (374), father of St Gregory the Theologian"
         ],
         "service_notes": null,
         "abbreviated_reading_indices": [

--- a/docs/saint-dedup-2026-08.md
+++ b/docs/saint-dedup-2026-08.md
@@ -97,6 +97,12 @@ All verified via `liturgics.Day(...)` spot checks (each merged date now shows ex
 
 (See also "Also noted, not acted on" under Pass 1 for the Cyril of Alexandria asymmetry, which isn't a duplicate but is worth Brian's attention separately)
 
+## Correction (caught by Brian in PR review)
+
+Three of the day-native-vs-additive merges (Basil of Amasea, Mark of Arethusa, Epiphanius of Cyprus) copied the additive entry's `full_name` verbatim, which conflated the solo saint's identity with a co-commemorated companion (Righteous Virgin Glaphyra; Cyril the Deacon; Germanos, Archbishop of Constantinople respectively) -- `full_name` is meant to be a solo identity descriptor, per Stage 4's own design. Fixed by trimming each `full_name` to describe only the one saint, preserving era/office context; the companion's name stays in the `story` prose, where mentioning them is legitimate narrative content, just not identity. The Nicomedia martyrs merge (5510) was *not* a case of this bug -- it's a genuine collective identity (the Saint row represents the whole group of 20,000, matching precedent like "Holy Forefathers Abraham, Isaac, and Jacob"), so its full_name correctly still describes the group. Andrew Stratelates' full_name mentioning "2,593 soldiers" was left as-is -- an anonymous mass under his command, not another named individual, and consistent with the pre-existing (not something this pass introduced) `name` field already reading "and Companions."
+
+127/127 tests pass after the fix; fixture re-diffed to confirm only these 3 `full_name` fields changed.
+
 ## Status
 
-Stopped here per explicit direction (spot-check + targeted scan rather than a full literal 366-date read) after 9 confirmed merges across 5 independent techniques, with strong convergent evidence the easily-findable duplicates are now cleared. Branch `saint-dedup-2026-08`, not yet committed or merged.
+Stopped here per explicit direction (spot-check + targeted scan rather than a full literal 366-date read) after 9 confirmed merges across 5 independent techniques, with strong convergent evidence the easily-findable duplicates are now cleared. Branch `saint-dedup-2026-08`, PR #157 open.

--- a/docs/saint-dedup-2026-08.md
+++ b/docs/saint-dedup-2026-08.md
@@ -1,0 +1,102 @@
+# Saint-identity duplicate consolidation, August 2026
+
+## Background
+
+Follow-on to `docs/saint-model-refactor.md` (PR #150, merged). That project's Stage 4 did a full pairwise duplicate survey (Jaccard token-overlap, threshold 0.4) across the ~1000 `Saint` rows that existed at the time and merged 25 confirmed pairs, requiring explicit cross-reference text in the source as the only reliable auto-confirm signal. Stage 11 (later, separate) added ~693 new `Saint` rows from a Greek-tradition harvest and deduped them against *existing* content, but never re-ran a fresh whole-corpus consolidation pass.
+
+Surfaced 2026-08-03 while reviewing what the (not-yet-shipped) MCP server's `search_saints` tool returns: St Seraphim of Sarov is split across two unlinked `Saint` rows (repose, pk 5111, vs. relics-uncovering, pk 5550) -- exactly the fragmentation problem Stage 4 existed to fix, missed because "Repose of..." vs. "Uncovering of the relics (1903) of..." only share 2/6 tokens (Jaccard 0.33), just under the 0.4 threshold used at the time.
+
+**Empirical scoping** (done before committing to an approach): a blind Jaccard rescan mirroring Stage 4's exact technique produced 2,144 candidates (~8x the original 287), verified by sampling to be dominated by noise from shared ecclesiastical-office vocabulary ("Patriarch of Constantinople," "Bishop of X") among the ~725 Greek-tradition `Saint` rows (only 5/725 have `full_name` set, vs. 853/934 for `common`-tradition rows, and almost none have story text -- i.e. no reliable signal). Not productive; abandoned in favor of the approach below.
+
+## Approach
+
+Mirrors Stage 11's proven 4-pass structure, in ascending cost order:
+
+1. Cross-reference-text scan (explicit phrases like "his main commemoration is," "also commemorated") -- cheapest, highest precision.
+2. Occasion-prefix-normalized exact-token scan.
+3. Fuzzy edit-distance scan (`SequenceMatcher` ratio >= 0.8, `autojunk=False`) for transliteration variants.
+4. Full day-by-day manual review of all ~366 calendar dates, all three traditions together, tracking a running "seen identities" registry to catch cross-date duplicates.
+
+**Verification bar for every merge**: never on name/token resemblance alone. Require explicit cross-reference text, or matching biographical detail cross-checked against an independent external source (OCA, ROCOR/holytrinityorthodox.com, antiochian.org, goarch.org) when ambiguous. Watch for: common first names alone, shared office/epithet across different centuries/people, joint identities incorrectly absorbing a solo occurrence.
+
+Scope is **all ~366 dates**, not just Stage 11's 315 Greek-harvest-affected ones -- Seraphim, Symeon, and Emilia (below) are all pre-Greek-harvest, `common`/`slavic`-tradition cases outside that narrower scope.
+
+## Progress log
+
+### Pass 1: cross-reference-text scan
+
+61 hits found (regex matched more broadly than the initial estimate). Reviewed all 61 individually rather than trusting the match alone -- most (58/61) were either already correctly linked (same `saint_id` on both ends of the cross-reference) or incidental mentions of a *different* person's commemoration date within a story (teacher/mentor/relative references with a parenthetical date, not an identity-duplicate signal at all -- a false-positive class the generic "commemorated on [month]" pattern is prone to). 3 genuine findings:
+
+- **St Seraphim of Sarov** (Saint 5111, repose Jan 2 vs. Saint 5550, relics-uncovering Jul 19) -- confirmed via each story's own text (5550's story literally ends "Saint Seraphim is commemorated January 2"). Merged: repointed `DayCommemoration` 5679 (Jul 19) onto Saint 5111, deleted Saint 5550. 5111 kept as canonical since its `full_name` includes the death year ("St Seraphim of Sarov (1833)") vs. 5550's plain "St Seraphim of Sarov".
+- **St Symeon the New Theologian** (Saint 5681, "repose" Mar 12 vs. Saint 5981, Oct 12) -- Mar 12's story is a pure 47-character stub ("His main commemoration is on October 12"), Oct 12 has the real ~1000-char biography which itself notes "(He reposed on March 12, but since this...[coincides with Lent])". Merged: repointed `DayCommemoration` 5810 (Mar 12) onto Saint 5981, deleted Saint 5681.
+- **St Emilia** (Saint 5595, mother of Sts Macrina/Basil the Great/Gregory of Nyssa) -- different shape of bug: not two Saint rows, but *one* Saint with two `DayCommemoration` rows (Jan 1 and May 8), both carrying the identical story text "Her main commemoration is on May 8" -- including on the May 8 entry itself, confirming both are copies of the same stub and Jan 1 is spurious (likely appended there as family background on St Basil the Great's own Jan 1 feast, not a real commemoration of her). Fixed by deleting the Jan 1 `DayCommemoration` row (5724), keeping the May 8 one (5878) and the Saint row itself.
+
+**Also noted, not acted on**: `dc=5401` (St Cyril of Alexandria, solo Saint 5292, Jun 9 repose) references Jan 18 as "the date of his restoration to his see" -- but unlike Athanasius (who got a solo Jan-18 split in the original Stage 4), Cyril has no dedicated Jan-18 `DayCommemoration` pointing to his solo identity; that occasion is still only visible via the joint "Ss Athanasius the Great and Cyril of Alexandria" Saint. This isn't a duplicate to merge (there's no second Cyril row), just an asymmetry in how thoroughly the original Athanasius/Cyril split was done -- flagged for Brian, not fixed here (would require adding a new `DayCommemoration` row, not consolidating an existing one).
+
+All verified via `liturgics.Day(...)` spot checks (dates and neighboring commemorations unaffected beyond the intended change) and the full test suite; `calendarium/tests/data/january.json` golden fixture updated for the Emilia removal (confirmed via full-month diff against the live API that it was the *only* change across all of January). 127/127 tests pass.
+
+### Pass 2: occasion-prefix scan
+
+5 candidates found; Seraphim/Symeon were already resolved via Pass 1 (same underlying pairs). The remaining 3 -- Julian the Martyr (3 rows: 3/16, 5/18, 9/12), Marinos the Martyr (2 rows: 3/17, 10/18), Zacharias the New Martyr (2 rows: 3/30, 5/28) -- were checked against the project's cached antiochian.org raw harvest (`data/antiochian_raw/2026-*.json`) since all 7 rows are bare `tradition='greek'` entries with no story or `full_name` to go on internally. Every date's source `feastDayDescription` lists the name with zero disambiguating detail (no epithet, era, or region) alongside a completely different, unrelated set of co-commemorated saints each time -- no cross-reference connecting any of the dates for a given name. Per the verification bar (name resemblance alone is not sufficient -- these are exactly the kind of common martyr name the original project repeatedly found belonged to different historical people), **left all three groups unmerged**. No DB changes this pass.
+
+### Pass 3: fuzzy edit-distance scan
+
+Built a token-level fuzzy scan (`SequenceMatcher` ratio >= 0.8, `autojunk=False`, comparing all ~2070 distinct tokens across the corpus pairwise, then mapping fuzzy-matching token pairs back to candidate Saint pairs with no exact token overlap). Found 598 fuzzy token pairs -> 3,872 candidate Saint pairs -- far more than Stage 11's original 40 hits, because Stage 11 ran this technique on a much narrower search (960 new entries vs. existing corpus, one direction), not all-pairs across the whole ~1667-Saint corpus.
+
+Spot-checked a filtered sample (~80 pairs where both fuzzy tokens are >= 7 characters, to skip short-word coincidences): overwhelmingly noise from genuinely different people who happen to share a Greek/Latin name-root or suffix variant (Eutychios/Eutychianos/Eutychius/Eutychianus are distinct individuals in the source, not spelling variants of one person; Cappadocia/Cappadocian, Thessalonica/Thessalonika/Thessaloniki are place-name adjective forms shared by unrelated people "of" that place). **One genuine hit** found by checking story content, not name similarity alone:
+
+- **Hieromartyr Theodoretus** (Saint 5674, `common`, Mar 8 -- full story: priest, custodian of a cathedral in Antioch, martyred under Julian the Apostate) and **Theodoretos the Holy Martyr of Antioch** (Saint 6298, `greek`, Mar 3, no story) -- same era, same city, same circumstance confirmed via the story text. Different dates per tradition (a real, previously-seen pattern -- St Catherine of Alexandria and Mercurius also have different Slavic vs. Greek commemoration dates). Merged the Saint identity, kept both `DayCommemoration` date rows: repointed the Mar 3 (`greek`) row onto Saint 5674, deleted Saint 6298.
+
+**Conclusion**: like the blind Jaccard rescan, blind fuzzy-token matching across the whole corpus doesn't productively narrow things down on its own -- both hit the same wall (no biographical anchor to confirm identity, especially for the ~725 story-less Greek-tradition rows). Not pursuing further tuning of this technique.
+
+**One more cheap high-precision check run before starting Pass 4**: exact-normalized-name matching (same name, different dates -- would catch a "Gregory of Assa added on 3 separate dates" -style verbatim repeat, the highest-precision signal available). Found only the same 3 already-reviewed-and-left-unmerged groups from Pass 2 (Julian/Marinos/Zacharias) -- nothing new. Between this, the blind Jaccard rescan, the fuzzy-token scan, and the cross-reference-text scan, the algorithmic techniques are now genuinely exhausted; remaining duplicates (if any) use different-enough wording for the same person that no string-matching heuristic can surface them. Pass 4 (manual review) is the only remaining path, exactly as Stage 11 concluded.
+
+**Also run before Pass 4**: a within-day check (same Jaccard technique, scoped to pairs on the *same* calendar date rather than the whole corpus -- much less noisy since the candidate pool per day is tiny). Found only 6 candidates across the whole year, all confirmed different people on inspection (e.g. Great Martyr Mercurius (ca. 259) vs. Holy Martyr Mercurius of Smolensk (1238) -- same name, ~900 years apart). No same-day duplication bug has crept back in since Stages 6/9/10 fixed the original version of this problem.
+
+### Pass 4: manual review (scoped to a sample, per Brian's direction)
+
+Given 5 independent techniques (blind Jaccard, occasion-prefix, fuzzy-token, exact-name, within-day) had converged on a small, exhausted result set, discussed scope directly with Brian rather than committing to reading all 366 dates blind. Agreed approach: spot-check a sample of months by hand, then use whatever pattern the sample surfaces to build one more *targeted* algorithmic pass covering the full year -- cheaper and more thorough than manual-only for a pattern that turns out to be well-defined.
+
+**Manually read April, August, and December in full** (135 + 166 + 131 = 432 `DayCommemoration` rows across all traditions, day by day). Found 2 new genuine duplicates, both a specific shape neither the Jaccard nor fuzzy-token scan caught -- a story-less `day_native` (terse-list) entry and a same-day story-bearing *additive* entry for the same person, whose Jaccard score fell just under the 0.5 within-day threshold because of transliteration/spelling differences ("Amasea" vs "Amasia", "20,000" vs "Twenty Thousand"):
+
+- **Hieromartyr Basil of Amasea/Amasia** (Apr 26): Saint 5242 (`day_native`, no story, `rank=3` from the recovered Paul Kachur typikon data) and Saint 5730 (additive, full story about Bishop Basil of Amasia sheltering St Glaphyra from Licinius) -- same person (place name spelled two ways). Merged: moved the story onto the day-native entry (preserving its `rank`), backfilled `full_name`, deleted the additive Saint/`DayCommemoration`.
+- **20,000 Martyrs of Nicomedia** (Dec 28): Saint 5510 (`day_native`, no story) and Saint 6088 (additive, full story, "Twenty Thousand" spelled out) -- same event. Same merge pattern.
+
+This is exactly the Stage-3-era bug pattern (a `day_native` entry and a matching additive story entry both surviving unrecognized as the same identity) recurring in a form the original per-day Jaccard check's threshold was too high to catch.
+
+**Built one targeted whole-year scan from this pattern**: every `(day_native, no story)` paired against every same-day `(additive, has story)` row, requiring only 1+ shared non-generic token (much lower threshold than the general within-day check, justified because this specific pairing shape is inherently low-noise -- a real duplicate of this shape is either genuinely obvious or a coincidence, not a spectrum). Found 32 candidates covering the *entire year*, not just the 3 sampled months. Reviewed all 32 individually (checking story content for era/place/circumstance match, not just token overlap):
+
+- **3 more genuine merges** (all same-day, same pattern as above): Hieromartyr Mark, Bishop of Arethusa (Mar 29, story confirms "Bishop of Arethusa in Syria... Julian the Apostate... 361"); St Epiphanius, Bishop of Cyprus (May 12, story confirms "born a Jew in Palestine... became a monk", joint mention of Germanos of Constantinople in the surviving entry is fine, Germanos has no other entry it could be robbing); Martyr Andrew Stratelates/Strateletes (Aug 19, story confirms "officer, a tribune... Persians attacked... title: commander, strateletes").
+- **27 correctly left unmerged**, mostly same-common-first-name-different-person (two different Sylvesters, two different Nicholases, two different Gregorys, two different Stephens/Theodores, etc. -- sharing only a generic office token like "bishop"/"hieromartyr"). One deliberately checked in detail and rejected: **Stephen the Martyr** (Sep 24, bare `greek` entry) vs. **St Stephen, First-crowned King of Serbia (Simon the Monk) (1224)** -- the story says he "entered into rest" peacefully as a monk, which doesn't even fit a "martyr" designation, confirming these are different people despite the shared first name.
+- Confirmed again (Aug 24, Hieromartyr Eutychius vs. Hieromartyr Eutyches) that the original project's own Stage 2 finding -- these are a deliberately-cleared *wrong* match, not a real duplicate -- still holds; correctly did not re-merge.
+
+**Not done**: the remaining ~9 months' worth of dates were not read line-by-line beyond what the targeted scan above already covers for this specific pattern. Given the targeted scan covers the *entire year* for the "day-native vs. additive, same day" shape (which accounts for 5 of the 7 new finds this pass), and the other techniques (cross-reference-text, fuzzy, exact-name) already covered the whole corpus for their respective patterns, coverage is broad even though not literally exhaustive line-by-line. A true "same person, completely different wording, different day, no shared vocabulary at all" case could still exist undetected -- this is the same residual risk the original project accepted after Stage 11.
+
+## Merges completed (9 total)
+
+- St Seraphim of Sarov: Saint 5550 (relics-uncovering, Jul 19) merged into Saint 5111 (repose, Jan 2).
+- St Symeon the New Theologian: Saint 5681 (Mar 12 stub) merged into Saint 5981 (Oct 12, full biography).
+- St Emilia: spurious duplicate `DayCommemoration` (Jan 1, pk 5724) deleted; May 8 (pk 5878) kept.
+- Hieromartyr Theodoretus: Saint 6298 (Mar 3, greek) merged into Saint 5674 (Mar 8, common) -- same person, tradition-specific date difference retained via separate `DayCommemoration` rows.
+- Hieromartyr Basil of Amasea/Amasia (Apr 26): Saint 5730 merged into day-native Saint 5242.
+- 20,000 Martyrs of Nicomedia (Dec 28): Saint 6088 merged into day-native Saint 5510.
+- Hieromartyr Mark, Bishop of Arethusa (Mar 29): Saint 5695 merged into day-native Saint 5215.
+- St Epiphanius, Bishop of Cyprus (May 12): Saint 5754 merged into day-native Saint 5255.
+- Martyr Andrew Stratelates (Aug 19): Saint 5885 merged into day-native Saint 5360.
+
+All verified via `liturgics.Day(...)` spot checks (each merged date now shows exactly one entry, no other saints/feasts on the date disturbed) and the full test suite (127/127 passing throughout).
+
+## Reviewed and deliberately left unmerged
+
+- Julian the Martyr (Saints 6339/6512/6842, dates 3/16, 5/18, 9/12) -- common martyr name, no distinguishing detail in source or local data; likely different people.
+- Marinos the Martyr (Saints 6342/6936, dates 3/17, 10/18) -- same reasoning.
+- Zacharias the New Martyr (Saints 6364/6533, dates 3/30, 5/28) -- same reasoning.
+- Stephen the Martyr (Sep 24) vs. St Stephen, First-crowned King of Serbia -- story contradicts a "martyr" designation for the king; different people.
+- Hieromartyr Eutychius vs. Hieromartyr Eutyches (Aug 24) -- reconfirmed the original project's own deliberate non-merge still holds.
+- ~26 other same-day-native-vs-additive candidates from the targeted scan, all sharing only a generic office/first-name token (bishop, hieromartyr, John, Nicholas, Gregory, Stephen, Theodore, etc.) between clearly different specific people.
+
+(See also "Also noted, not acted on" under Pass 1 for the Cyril of Alexandria asymmetry, which isn't a duplicate but is worth Brian's attention separately)
+
+## Status
+
+Stopped here per explicit direction (spot-check + targeted scan rather than a full literal 366-date read) after 9 confirmed merges across 5 independent techniques, with strong convergent evidence the easily-findable duplicates are now cleared. Branch `saint-dedup-2026-08`, not yet committed or merged.

--- a/fixtures/commemorations.json
+++ b/fixtures/commemorations.json
@@ -796,7 +796,7 @@
   "pk": 5215,
   "fields": {
     "name": "Hieromartyr Mark, Bishop of Arethusa",
-    "full_name": null
+    "full_name": "Our Righteous Father Mark the Confessor, Bishop of Arethusa; Cyril the Deacon, and others martyred during the reign of Julian"
   }
 },
 {
@@ -988,7 +988,7 @@
   "pk": 5242,
   "fields": {
     "name": "Hieromartyr Basil of Amasea",
-    "full_name": null
+    "full_name": "Hieromartyr Basil, bishop of Amasia and Righteous Virgin Glaphyra (322)"
   }
 },
 {
@@ -1084,7 +1084,7 @@
   "pk": 5255,
   "fields": {
     "name": "St Epiphanius, Bishop of Cyprus",
-    "full_name": null
+    "full_name": "Our Fathers among the Saints Epiphanios, bishop of Cyprus (403) and Germanos, Archbishop of Constantinople (740)"
   }
 },
 {
@@ -1876,7 +1876,7 @@
   "pk": 5360,
   "fields": {
     "name": "Martyr Andrew Stratelates and Companions",
-    "full_name": null
+    "full_name": "Martyr Andrew Strateletes and 2,593 soldiers with him in Cilicia (ca. 289)"
   }
 },
 {
@@ -3012,7 +3012,7 @@
   "pk": 5510,
   "fields": {
     "name": "20,000 Martyrs of Nicomedia",
-    "full_name": null
+    "full_name": "The Twenty Thousand Martyrs burned to death in their church in Nicomedia (ca. 304)."
   }
 },
 {
@@ -3301,14 +3301,6 @@
   "fields": {
     "name": "Holy Equal-to-the-Apostles Great Prince Vladimir (in holy baptism Basil), enlightener of the Russian Land (1051)",
     "full_name": "Holy Equal-to-the-Apostles Great Prince Vladimir (in holy baptism Basil), enlightener of the Russian Land (1051)"
-  }
-},
-{
-  "model": "commemorations.saint",
-  "pk": 5550,
-  "fields": {
-    "name": "Uncovering of the relics (1903) of St Seraphim of Sarov",
-    "full_name": "St Seraphim of Sarov"
   }
 },
 {
@@ -4273,14 +4265,6 @@
 },
 {
   "model": "commemorations.saint",
-  "pk": 5681,
-  "fields": {
-    "name": "Repose of St Symeon the New Theologian (1021)",
-    "full_name": "St Symeon the New Theologian (1021)"
-  }
-},
-{
-  "model": "commemorations.saint",
   "pk": 5682,
   "fields": {
     "name": "St Theognostus, Metropolitan of Kiev (1353)",
@@ -4381,14 +4365,6 @@
   "fields": {
     "name": "Repose of Gerontissa Gavrilia (1992) (March 15 OC)",
     "full_name": "Gerontissa Gavrilia (1992) (March 15 OC)"
-  }
-},
-{
-  "model": "commemorations.saint",
-  "pk": 5695,
-  "fields": {
-    "name": "Our Righteous Father Mark the Confessor, Bishop of Arethusa; Cyril the Deacon, and others martyred during the reign of Julian",
-    "full_name": "Our Righteous Father Mark the Confessor, Bishop of Arethusa; Cyril the Deacon, and others martyred during the reign of Julian"
   }
 },
 {
@@ -4649,14 +4625,6 @@
 },
 {
   "model": "commemorations.saint",
-  "pk": 5730,
-  "fields": {
-    "name": "Hieromartyr Basil, bishop of Amasia and Righteous Virgin Glaphyra (322)",
-    "full_name": "Hieromartyr Basil, bishop of Amasia and Righteous Virgin Glaphyra (322)"
-  }
-},
-{
-  "model": "commemorations.saint",
   "pk": 5731,
   "fields": {
     "name": "Our Holy Father Stephen, Abbot of the Kiev Caves and Bishop of Vladimir (1094)",
@@ -4829,14 +4797,6 @@
   "fields": {
     "name": "Holy Hieromartyr Mocius (288? 295?)",
     "full_name": "Holy Hieromartyr Mocius (288? 295?)"
-  }
-},
-{
-  "model": "commemorations.saint",
-  "pk": 5754,
-  "fields": {
-    "name": "Our Fathers among the Saints Epiphanios, bishop of Cyprus (403) and Germanos, Archbishop of Constantinople (740)",
-    "full_name": "Our Fathers among the Saints Epiphanios, bishop of Cyprus (403) and Germanos, Archbishop of Constantinople (740)"
   }
 },
 {
@@ -5853,14 +5813,6 @@
   "fields": {
     "name": "Our Holy Father John, Abbot of Rila (946)",
     "full_name": "Our Holy Father John, Abbot of Rila (946)"
-  }
-},
-{
-  "model": "commemorations.saint",
-  "pk": 5885,
-  "fields": {
-    "name": "Martyr Andrew Strateletes and 2,593 soldiers with him in Cilicia (ca. 289)",
-    "full_name": "Martyr Andrew Strateletes and 2,593 soldiers with him in Cilicia (ca. 289)"
   }
 },
 {
@@ -7449,14 +7401,6 @@
 },
 {
   "model": "commemorations.saint",
-  "pk": 6088,
-  "fields": {
-    "name": "The Twenty Thousand Martyrs burned to death in their church in Nicomedia (ca. 304).",
-    "full_name": "The Twenty Thousand Martyrs burned to death in their church in Nicomedia (ca. 304)."
-  }
-},
-{
-  "model": "commemorations.saint",
   "pk": 6089,
   "fields": {
     "name": "Our Holy Father Simon the Outpourer of Myrrh, Founder of Simonopetra Monastery, Mt Athos (1287)",
@@ -8852,14 +8796,6 @@
   "pk": 6297,
   "fields": {
     "name": "Chad, Bishop of Lichfield",
-    "full_name": null
-  }
-},
-{
-  "model": "commemorations.saint",
-  "pk": 6298,
-  "fields": {
-    "name": "Theodoretos the Holy Martyr of Antioch",
     "full_name": null
   }
 },
@@ -15022,7 +14958,7 @@
     "day": 524,
     "saint": 5215,
     "title": "Hieromartyr Mark, Bishop of Arethusa",
-    "story": null,
+    "story": "<p>“<i>Saint Mark</i> was Bishop of Arethusa in Syria. In the days of Saint Constantine the Great, Saint Mark, moved with divine zeal, destroyed a temple of the idols and raised up a church in its stead. When Julian the Apostate reigned, in 361, as the pagans were now able to avenge the destruction of their temple, Saint Mark, giving way to wrath, hid himself; but when he saw that others were being taken on his account, he gave himself up. Having no regard to his old age, they stripped him and beat his whole body, cast him into filthy sewers, and pulling him out, had children prick him with their iron writing-pens. Then they put him into a basket, smeared him with honey and a kind of relish of pickled fish, and hung him up under the burning sun to be devoured by bees and wasps. But because he bore this so nobly, his enemies repented, and unloosed him.</p>\n<p>“<i>Saint Cyril</i> was a deacon from Heliopolis in Phoenecia. During the reign of the Emperor Constantius, son of Saint Constantine, he had also broken the idols in pieces. When Julian came to power, Saint Cyril was seized by the idolators and his belly was ripped open. The other holy Martyrs celebrated today, martyred in Gaza and Ascalon during the reign of Julian, were men of priestly rank and consecrated virgins; they were disemboweled, filled with barley, and set before swine to be eaten. The account of all the above Saints is given in Book III, ch. 3, of Theodoret of Cyrrhus’ <i>Ecclesiastical History.</i> (<i>Great Horologion</i>)</p>",
     "rank": 0,
     "high_rank": false,
     "new_style": false,
@@ -15454,7 +15390,7 @@
     "day": 552,
     "saint": 5242,
     "title": "Hieromartyr Basil of Amasea",
-    "story": null,
+    "story": "<p>Licinius was co-emperor with Constantine the Great. At his accession, he had agreed to tolerate Christianity in his territories, but soon turned to persecuting the Christians, and to a variety of carnal sins. He conceived a passion for Glaphyra, a Christian virgin handmaid of the Empress Constantia. When Glaphyra told Constantia of this, the Empress sent her away to Amasia in the East for her protection. There she was received and protected by Bishop Basil of that city. Licinius learned where Glaphyra was hiding and ordered that both she and the bishop be brought to him as prisoners. The soldiers who came for her found that she had already died, so they returned with only Bishop Basil, who was subjected to cruel tortures, then beheaded. His body was cast into the sea, but, with the help of an angel of God, his people found his body, retrieved it from the sea, and returned it to Amasia.</p>\n<p>The <i>Prologue</i> adds, “The Emperor Constantine raised an army against Licinius, overcame him, arrested him and sent him into exile in Gaul, where he ended his God-hating days.”</p>",
     "rank": 3,
     "high_rank": false,
     "new_style": false,
@@ -15662,7 +15598,7 @@
     "day": 568,
     "saint": 5255,
     "title": "St Epiphanius, Bishop of Cyprus",
-    "story": null,
+    "story": "<p><i>Saint Epiphanios</i> was born a Jew in Palestine, but he and his sister came to faith in Christ and were baptized together. Epiphanios gave all his possessions to the poor and became a monk. He knew St Hilarion the great (October 31), and traveled among the monks of Egypt to learn their ways and wisdom. The fame of his virtue spread so widely that several attempts were made to make him bishop, first in Egypt, then in Cyprus. Whenever Epiphanios heard of these plans, he fled the area. He was finally made bishop by means of a storm: told to go to Cyprus, he took ship instead for Gaza, but a contrary wind blew his ship directly to Cyprus, where “Epiphanios fell into the hands of bishops who had come together to elect a successor to the newly-departed Bishop of Constantia, and the venerable Epiphanios was at last constrained to be consecrated, about the year 367.” (<i>Great Horologion</i>). He guarded his flock faithfully for the remainder of his life, working many miracles, defending the Church against the Arian heresy, and composing several books, of which the best-loved is the <i>Panarion</i> (from the Latin for ‘bread-box’), an exposition of the Faith and an examination of eighty heresies. He was sometimes called the ‘Five-tongued’ because he was fluent in Hebrew, Egyptian, Syriac, Greek, and Latin.</p>\n<p><i>Saint Germanos</i> was the son of a prominent family, in Constantinople. He became Metropolitan of Cyzicus, then was elevated to the throne at Constantinople in 715. It was he who baptized the infant Constantine, who for his whole life was nicknamed “Copronymos” because he defecated in the baptismal font (though he was neither the first nor the last infant to do so). At this incident, Patriarch Germanos is said to have prophesied that the child would one day bring some foul heresy upon the Church, which he did, becoming a notorious iconoclast as emperor. Germanos openly opposed the decree of the Emperor Leo the Isaurian which began the persecution of the holy icons. For this he was deposed and driven into exile in 730. He lived the rest of his life in peace. Saint Germanos is the composer of many of the Church’s hymns, notably those for the Feast of the Meeting in the Temple.</p>\n<p>These two Saints are always commemorated together.</p>",
     "rank": 0,
     "high_rank": false,
     "new_style": false,
@@ -17358,7 +17294,7 @@
     "day": 667,
     "saint": 5360,
     "title": "Martyr Andrew Stratelates and Companions",
-    "story": null,
+    "story": "<p>“He was an officer, a tribune, in the Roman army in the time of the Emperor Maximian. A Syrian by birth, he served in his native land. When the Persians attacked the imperial Roman army, this Andrew was entrusted with the command in the battle against the enemy — whence his title: commander, <i>strateletes</i>. A secret Christian, although as yet unbaptised, Andrew commended himself to the living God, and, taking only the cream of the army, went to war. Before the battle, he told his soldiers that, if they all called upon the aid of the one, true God, Christ the Lord, their enemies would become as dust scattered before them. All the soldiers, fired with enthusiasm by Andrew and his faith, invoked Christ’s aid and attacked. The Persian army was utterly routed. When the victorious Andrew returned to Antioch, some jealous men denounced him as a Christian and the imperial governor summoned him for trial. Andrew openly proclaimed his steadfast faith in Christ. After harsh torture, the governor threw Andrew into prison and wrote to the Emperor in Rome. Knowing Andrew’s popularity among the people and in the army, the Emperor ordered the governor to set Andrew free, but to seek another occasion and another excuse (not his faith) to kill him. By God’s revelation, Andrew came to know of this imperial command, and, taking his faithful soldiers (2,593 in all) with him, went off to Tarsus in Cilicia, where they were all baptised by the bishop, Peter. Persecuted here also by imperial might, Andrew and his companions withdrew deep into the Armenian mountain of Tavros. There in a ravine, while they were at prayer, the Roman army came upon them and beheaded them all. Not one of them would recant, all being determined on death by martyrdom for Christ. On the spot where a stream of the martyrs’ blood flowed down, a spring of healing water sprang forth, healing from every disease. The bishop, Peter, came secretly with his people and buried the martyrs’ bodies in that same place. They all suffered with honour at the end of the third century and were crowned with wreaths of eternal glory, entering into the Kingdom of Christ our God.” (<i>Prologue</i>)</p>",
     "rank": 0,
     "high_rank": false,
     "new_style": false,
@@ -19726,7 +19662,7 @@
     "day": 798,
     "saint": 5510,
     "title": "20,000 Martyrs of Nicomedia",
-    "story": null,
+    "story": "<p>During a fierce persecution by the Emperor Maximian of all who would not worship the idols, the Christians of Nicomedia were subjected to especially savage treatment. (Eusebius writes that every Christian in the city was killed.) Along with many others put to the sword or otherwise butchered there, we especially commemorate the large company who, despite all danger, gathered in the church to commemorate Christ’s Nativity. The Emperor, hearing of this, sent troops to surround the building so that no-one could escape, and piled heaps of timber and brush around it. Criers then gave notice that any who wished to save their lives must come out and make sacrifice to the pagan gods.</p>\n<p>“As this announcement penetrated the church, a divine zeal, more fiery than any flame in the world, seized the deacon Agapius, who rushed to the pulpit and cried out, ‘Brethren, remember how often we have praised and extolled the Three Young Men who, when they were thrown into the Babylonian furnace, called on the whole of Creation to sing the glory of God, and how the All-Creating Word then came down in bodily appearance, to assist them and to render them invulnerable by surrounding them with a moist whistling wind. The time has now come for us to imitate them. Let us offer ourselves to a temporary death for love of our Master, in order to reign everlastingly with Him!’ The whole congregation with one voice then answered Maximian’s criers, ‘We believe in Christ God and we will give up our lives for Him!’</p>\n<p>“As the soldiers began to set fire to the piles of wood outside, Saint Anthimus [bishop of the city, commemorated September 3] told his deacons to assemble those who were still catechumens, and he baptized and anointed them with the holy Myron. He then served the divine Liturgy, at which all present communicated in the Body and Blood of Our Lord Jesus Christ. Armed with divine strength and closely united in a single body by Christ who dwelt in them, the holy Martyrs felt no fear as they saw the flames leap up everywhere and thick smoke begin to fill the church. With gladness they sang in unison the Song of the Three Young Men: Bless the Lord, all works of the Lord, sing praise to Him and highly exalt Him for ever (Dan. 3 LXX) until the last among them suffocated and gave up his soul.</p>\n<p>“The conflagration lasted for five days. Those who then ventured into the smouldering ruins anticipating the odour of charred flesh, found instead a heavenly scent pervading the air and the place surrounded by a brilliant light. The Saints who were glorified at this time are said to have numbered twenty thousand. Saint Anthimus himself miraculously escaped death, and so was able by his teaching to lead a large number of souls to salvation and to the new birth of holy Baptism before, in his turn, fulfilling his union with Christ by martyrdom.” <i>(Synaxarion)</i></p>",
     "rank": 0,
     "high_rank": false,
     "new_style": false,
@@ -20364,7 +20300,7 @@
   "pk": 5679,
   "fields": {
     "day": 636,
-    "saint": 5550,
+    "saint": 5111,
     "title": "Uncovering of the relics (1903) of St Seraphim of Sarov",
     "story": "<p>“The uncovering of the holy relics of St Seraphim of Sarov on July 19, 1903 was attended by many thousands, among them the foremost of the clergy and royalty; the holy Tsar Nicholas II (July 4) was one of the bearers of the relics in procession, and the Grand Duchess Elizabeth (July 5) wrote an eyewitness account of the many miracles that took place. Not only had the Saint foretold the coming of the Tsar to his glorification, and that from joy they would chant ‘Christ is Risen’ in summer, but he also left a letter ‘for the fourth sovereign, who will come to Sarov.’ This was Nicholas II, who was given the letter when he came in 1903; the contents of the letter are not known, but when he had read it, the Tsar and future Martyr, though not a man to show his emotions, was visibly shaken.” (<i>Great Horologion</i>)</p>\n<p>Saint Seraphim is commemorated January 2.</p>",
     "rank": 0,
@@ -21076,22 +21012,6 @@
     "new_style": false,
     "day_native": false,
     "ordering": 2,
-    "tradition": "common"
-  }
-},
-{
-  "model": "commemorations.daycommemoration",
-  "pk": 5724,
-  "fields": {
-    "day": 436,
-    "saint": 5595,
-    "title": "St Emilia (375), mother of Sts Macrina, Basil the Great and Gregory of Nyssa, Peter of Sebaste, and Theosevia",
-    "story": "<p>Her main commemoration is on May 8.</p>",
-    "rank": 0,
-    "high_rank": false,
-    "new_style": false,
-    "day_native": false,
-    "ordering": 3,
     "tradition": "common"
   }
 },
@@ -22428,7 +22348,7 @@
   "pk": 5810,
   "fields": {
     "day": 507,
-    "saint": 5681,
+    "saint": 5981,
     "title": "Repose of St Symeon the New Theologian (1021)",
     "story": "<p>His main commemoration is on October 12.</p>",
     "rank": 0,
@@ -22644,22 +22564,6 @@
     "new_style": true,
     "day_native": false,
     "ordering": 1,
-    "tradition": "common"
-  }
-},
-{
-  "model": "commemorations.daycommemoration",
-  "pk": 5824,
-  "fields": {
-    "day": 524,
-    "saint": 5695,
-    "title": "Our Righteous Father Mark the Confessor, Bishop of Arethusa; Cyril the Deacon, and others martyred during the reign of Julian",
-    "story": "<p>“<i>Saint Mark</i> was Bishop of Arethusa in Syria. In the days of Saint Constantine the Great, Saint Mark, moved with divine zeal, destroyed a temple of the idols and raised up a church in its stead. When Julian the Apostate reigned, in 361, as the pagans were now able to avenge the destruction of their temple, Saint Mark, giving way to wrath, hid himself; but when he saw that others were being taken on his account, he gave himself up. Having no regard to his old age, they stripped him and beat his whole body, cast him into filthy sewers, and pulling him out, had children prick him with their iron writing-pens. Then they put him into a basket, smeared him with honey and a kind of relish of pickled fish, and hung him up under the burning sun to be devoured by bees and wasps. But because he bore this so nobly, his enemies repented, and unloosed him.</p>\n<p>“<i>Saint Cyril</i> was a deacon from Heliopolis in Phoenecia. During the reign of the Emperor Constantius, son of Saint Constantine, he had also broken the idols in pieces. When Julian came to power, Saint Cyril was seized by the idolators and his belly was ripped open. The other holy Martyrs celebrated today, martyred in Gaza and Ascalon during the reign of Julian, were men of priestly rank and consecrated virgins; they were disemboweled, filled with barley, and set before swine to be eaten. The account of all the above Saints is given in Book III, ch. 3, of Theodoret of Cyrrhus’ <i>Ecclesiastical History.</i> (<i>Great Horologion</i>)</p>",
-    "rank": 0,
-    "high_rank": false,
-    "new_style": false,
-    "day_native": false,
-    "ordering": 0,
     "tradition": "common"
   }
 },
@@ -23209,22 +23113,6 @@
 },
 {
   "model": "commemorations.daycommemoration",
-  "pk": 5859,
-  "fields": {
-    "day": 552,
-    "saint": 5730,
-    "title": "Hieromartyr Basil, bishop of Amasia and Righteous Virgin Glaphyra (322)",
-    "story": "<p>Licinius was co-emperor with Constantine the Great. At his accession, he had agreed to tolerate Christianity in his territories, but soon turned to persecuting the Christians, and to a variety of carnal sins. He conceived a passion for Glaphyra, a Christian virgin handmaid of the Empress Constantia. When Glaphyra told Constantia of this, the Empress sent her away to Amasia in the East for her protection. There she was received and protected by Bishop Basil of that city. Licinius learned where Glaphyra was hiding and ordered that both she and the bishop be brought to him as prisoners. The soldiers who came for her found that she had already died, so they returned with only Bishop Basil, who was subjected to cruel tortures, then beheaded. His body was cast into the sea, but, with the help of an angel of God, his people found his body, retrieved it from the sea, and returned it to Amasia.</p>\n<p>The <i>Prologue</i> adds, “The Emperor Constantine raised an army against Licinius, overcame him, arrested him and sent him into exile in Gaul, where he ended his God-hating days.”</p>",
-    "rank": 0,
-    "high_rank": false,
-    "new_style": false,
-    "day_native": false,
-    "ordering": 0,
-    "tradition": "common"
-  }
-},
-{
-  "model": "commemorations.daycommemoration",
   "pk": 5860,
   "fields": {
     "day": 553,
@@ -23604,22 +23492,6 @@
     "new_style": false,
     "day_native": false,
     "ordering": 1,
-    "tradition": "common"
-  }
-},
-{
-  "model": "commemorations.daycommemoration",
-  "pk": 5884,
-  "fields": {
-    "day": 568,
-    "saint": 5754,
-    "title": "Our Fathers among the Saints Epiphanios, bishop of Cyprus (403) and Germanos, Archbishop of Constantinople (740)",
-    "story": "<p><i>Saint Epiphanios</i> was born a Jew in Palestine, but he and his sister came to faith in Christ and were baptized together. Epiphanios gave all his possessions to the poor and became a monk. He knew St Hilarion the great (October 31), and traveled among the monks of Egypt to learn their ways and wisdom. The fame of his virtue spread so widely that several attempts were made to make him bishop, first in Egypt, then in Cyprus. Whenever Epiphanios heard of these plans, he fled the area. He was finally made bishop by means of a storm: told to go to Cyprus, he took ship instead for Gaza, but a contrary wind blew his ship directly to Cyprus, where “Epiphanios fell into the hands of bishops who had come together to elect a successor to the newly-departed Bishop of Constantia, and the venerable Epiphanios was at last constrained to be consecrated, about the year 367.” (<i>Great Horologion</i>). He guarded his flock faithfully for the remainder of his life, working many miracles, defending the Church against the Arian heresy, and composing several books, of which the best-loved is the <i>Panarion</i> (from the Latin for ‘bread-box’), an exposition of the Faith and an examination of eighty heresies. He was sometimes called the ‘Five-tongued’ because he was fluent in Hebrew, Egyptian, Syriac, Greek, and Latin.</p>\n<p><i>Saint Germanos</i> was the son of a prominent family, in Constantinople. He became Metropolitan of Cyzicus, then was elevated to the throne at Constantinople in 715. It was he who baptized the infant Constantine, who for his whole life was nicknamed “Copronymos” because he defecated in the baptismal font (though he was neither the first nor the last infant to do so). At this incident, Patriarch Germanos is said to have prophesied that the child would one day bring some foul heresy upon the Church, which he did, becoming a notorious iconoclast as emperor. Germanos openly opposed the decree of the Emperor Leo the Isaurian which began the persecution of the holy icons. For this he was deposed and driven into exile in 730. He lived the rest of his life in peace. Saint Germanos is the composer of many of the Church’s hymns, notably those for the Feast of the Meeting in the Temple.</p>\n<p>These two Saints are always commemorated together.</p>",
-    "rank": 0,
-    "high_rank": true,
-    "new_style": false,
-    "day_native": false,
-    "ordering": 0,
     "tradition": "common"
   }
 },
@@ -25700,22 +25572,6 @@
     "new_style": false,
     "day_native": false,
     "ordering": 1,
-    "tradition": "common"
-  }
-},
-{
-  "model": "commemorations.daycommemoration",
-  "pk": 6015,
-  "fields": {
-    "day": 667,
-    "saint": 5885,
-    "title": "Martyr Andrew Strateletes and 2,593 soldiers with him in Cilicia (ca. 289)",
-    "story": "<p>“He was an officer, a tribune, in the Roman army in the time of the Emperor Maximian. A Syrian by birth, he served in his native land. When the Persians attacked the imperial Roman army, this Andrew was entrusted with the command in the battle against the enemy — whence his title: commander, <i>strateletes</i>. A secret Christian, although as yet unbaptised, Andrew commended himself to the living God, and, taking only the cream of the army, went to war. Before the battle, he told his soldiers that, if they all called upon the aid of the one, true God, Christ the Lord, their enemies would become as dust scattered before them. All the soldiers, fired with enthusiasm by Andrew and his faith, invoked Christ’s aid and attacked. The Persian army was utterly routed. When the victorious Andrew returned to Antioch, some jealous men denounced him as a Christian and the imperial governor summoned him for trial. Andrew openly proclaimed his steadfast faith in Christ. After harsh torture, the governor threw Andrew into prison and wrote to the Emperor in Rome. Knowing Andrew’s popularity among the people and in the army, the Emperor ordered the governor to set Andrew free, but to seek another occasion and another excuse (not his faith) to kill him. By God’s revelation, Andrew came to know of this imperial command, and, taking his faithful soldiers (2,593 in all) with him, went off to Tarsus in Cilicia, where they were all baptised by the bishop, Peter. Persecuted here also by imperial might, Andrew and his companions withdrew deep into the Armenian mountain of Tavros. There in a ravine, while they were at prayer, the Roman army came upon them and beheaded them all. Not one of them would recant, all being determined on death by martyrdom for Christ. On the spot where a stream of the martyrs’ blood flowed down, a spring of healing water sprang forth, healing from every disease. The bishop, Peter, came secretly with his people and buried the martyrs’ bodies in that same place. They all suffered with honour at the end of the third century and were crowned with wreaths of eternal glory, entering into the Kingdom of Christ our God.” (<i>Prologue</i>)</p>",
-    "rank": 0,
-    "high_rank": false,
-    "new_style": false,
-    "day_native": false,
-    "ordering": 0,
     "tradition": "common"
   }
 },
@@ -28921,22 +28777,6 @@
 },
 {
   "model": "commemorations.daycommemoration",
-  "pk": 6218,
-  "fields": {
-    "day": 798,
-    "saint": 6088,
-    "title": "The Twenty Thousand Martyrs burned to death in their church in Nicomedia (ca. 304).",
-    "story": "<p>During a fierce persecution by the Emperor Maximian of all who would not worship the idols, the Christians of Nicomedia were subjected to especially savage treatment. (Eusebius writes that every Christian in the city was killed.) Along with many others put to the sword or otherwise butchered there, we especially commemorate the large company who, despite all danger, gathered in the church to commemorate Christ’s Nativity. The Emperor, hearing of this, sent troops to surround the building so that no-one could escape, and piled heaps of timber and brush around it. Criers then gave notice that any who wished to save their lives must come out and make sacrifice to the pagan gods.</p>\n<p>“As this announcement penetrated the church, a divine zeal, more fiery than any flame in the world, seized the deacon Agapius, who rushed to the pulpit and cried out, ‘Brethren, remember how often we have praised and extolled the Three Young Men who, when they were thrown into the Babylonian furnace, called on the whole of Creation to sing the glory of God, and how the All-Creating Word then came down in bodily appearance, to assist them and to render them invulnerable by surrounding them with a moist whistling wind. The time has now come for us to imitate them. Let us offer ourselves to a temporary death for love of our Master, in order to reign everlastingly with Him!’ The whole congregation with one voice then answered Maximian’s criers, ‘We believe in Christ God and we will give up our lives for Him!’</p>\n<p>“As the soldiers began to set fire to the piles of wood outside, Saint Anthimus [bishop of the city, commemorated September 3] told his deacons to assemble those who were still catechumens, and he baptized and anointed them with the holy Myron. He then served the divine Liturgy, at which all present communicated in the Body and Blood of Our Lord Jesus Christ. Armed with divine strength and closely united in a single body by Christ who dwelt in them, the holy Martyrs felt no fear as they saw the flames leap up everywhere and thick smoke begin to fill the church. With gladness they sang in unison the Song of the Three Young Men: Bless the Lord, all works of the Lord, sing praise to Him and highly exalt Him for ever (Dan. 3 LXX) until the last among them suffocated and gave up his soul.</p>\n<p>“The conflagration lasted for five days. Those who then ventured into the smouldering ruins anticipating the odour of charred flesh, found instead a heavenly scent pervading the air and the place surrounded by a brilliant light. The Saints who were glorified at this time are said to have numbered twenty thousand. Saint Anthimus himself miraculously escaped death, and so was able by his teaching to lead a large number of souls to salvation and to the new birth of holy Baptism before, in his turn, fulfilling his union with Christ by martyrdom.” <i>(Synaxarion)</i></p>",
-    "rank": 0,
-    "high_rank": false,
-    "new_style": false,
-    "day_native": false,
-    "ordering": 0,
-    "tradition": "common"
-  }
-},
-{
-  "model": "commemorations.daycommemoration",
   "pk": 6219,
   "fields": {
     "day": 798,
@@ -31820,7 +31660,7 @@
   "pk": 6434,
   "fields": {
     "day": 498,
-    "saint": 6298,
+    "saint": 5674,
     "title": "Theodoretos the Holy Martyr of Antioch",
     "story": null,
     "rank": 0,

--- a/fixtures/commemorations.json
+++ b/fixtures/commemorations.json
@@ -796,7 +796,7 @@
   "pk": 5215,
   "fields": {
     "name": "Hieromartyr Mark, Bishop of Arethusa",
-    "full_name": "Our Righteous Father Mark the Confessor, Bishop of Arethusa; Cyril the Deacon, and others martyred during the reign of Julian"
+    "full_name": "Our Righteous Father Mark the Confessor, Bishop of Arethusa, martyred during the reign of Julian"
   }
 },
 {
@@ -988,7 +988,7 @@
   "pk": 5242,
   "fields": {
     "name": "Hieromartyr Basil of Amasea",
-    "full_name": "Hieromartyr Basil, bishop of Amasia and Righteous Virgin Glaphyra (322)"
+    "full_name": "Hieromartyr Basil, Bishop of Amasia (322)"
   }
 },
 {
@@ -1084,7 +1084,7 @@
   "pk": 5255,
   "fields": {
     "name": "St Epiphanius, Bishop of Cyprus",
-    "full_name": "Our Fathers among the Saints Epiphanios, bishop of Cyprus (403) and Germanos, Archbishop of Constantinople (740)"
+    "full_name": "Our Father among the Saints Epiphanios, Bishop of Cyprus (403)"
   }
 },
 {


### PR DESCRIPTION
## Summary
- Found while reviewing MCP `search_saints` output: St Seraphim of Sarov was split across two unlinked `Saint` rows (repose vs. relics-uncovering), a gap in the original `saint-model-refactor` project's Stage 4 consolidation pass (missed the pair by a small margin under its Jaccard threshold).
- Scoped further duplicates via five techniques (cross-reference-text scan, occasion-prefix matching, fuzzy edit-distance, exact-name matching, and a targeted day-native-vs-additive scan built from patterns found while manually sampling three months of data) — full methodology and per-case reasoning in `docs/saint-dedup-2026-08.md`.
- Merged 9 confirmed duplicate identities and deleted one spurious commemoration entry (St Emilia's misplaced Jan 1 row); several likely-looking candidates (common martyr names like "Julian the Martyr") were deliberately left unmerged after checking the source data showed no distinguishing detail.

## Test plan
- [x] `docker compose run --rm tests` — 127/127 passing
- [x] Golden fixture (`calendarium/tests/data/january.json`) regenerated and diffed against the live API to confirm only the intended change landed
- [x] Each merge spot-checked via `liturgics.Day(...)` to confirm no unrelated feast/fast/saint data was disturbed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3