### PR TITLE
Fix production 421 "Invalid Host header" on /mcp

### DIFF
--- a/orthocal/asgi.py
+++ b/orthocal/asgi.py
@@ -13,6 +13,7 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'orthocal.settings')
 
 from django.conf import settings
 from django.core.asgi import get_asgi_application
+from mcp.server.transport_security import TransportSecuritySettings
 
 django_application = get_asgi_application()
 
@@ -24,7 +25,19 @@ from mcp_svc.server import mcp
 # owns its own /mcp route and lifespan (which starts/stops its session
 # manager's background task). Django's ASGIHandler doesn't implement the
 # lifespan protocol at all, so lifespan scope is only ever handled here.
-mcp_application = mcp.streamable_http_app()
+#
+# transport_security must be set explicitly: with no host argument, the SDK
+# defaults host to '127.0.0.1' and auto-enables DNS-rebinding protection
+# restricted to localhost -- fine in local dev, but it rejects every real
+# request in production (Cloud Run's own hostname as the Host header,
+# forwarded by the Firebase Hosting proxy in front of it, isn't on that
+# allowlist). DNS-rebinding protection defends a server bound to localhost
+# against a malicious webpage's JS reaching it through the browser; it
+# doesn't apply to a public HTTPS API with no localhost-only trust boundary,
+# so disabling it here is the correct fix, not a workaround.
+mcp_application = mcp.streamable_http_app(
+    transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
+)
 
 
 async def application(scope, receive, send):


### PR DESCRIPTION
## Summary
- `/mcp` returned 421 "Invalid Host header" for every real request in production, confirmed via Cloud Run logs (`Invalid Host header: orthocal-6czswbhara-uc.a.run.app` on every request since PR #158 merged).
- Root cause: `orthocal/asgi.py` called `mcp.streamable_http_app()` with no arguments. The SDK defaults `host='127.0.0.1'` in that case, which auto-enables DNS-rebinding protection restricted to `localhost`/`127.0.0.1`/`::1` — fine in local dev (where the Host header naturally is `localhost`), but it rejects every real production request, since Cloud Run's own hostname (forwarded as the Host header by the Firebase Hosting proxy in front of it) isn't on that allowlist.
- Fix: explicitly pass `transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False)`. DNS-rebinding protection defends a server bound to localhost against a malicious webpage's JS reaching it through the browser — it doesn't apply to a public HTTPS API with no localhost-only trust boundary, so disabling it here is the correct fix, not a workaround.

## Test plan
- [x] `docker compose run --rm tests` — 135/135 passing
- [x] Verified locally by replaying the exact Host header from the production error logs (`Host: orthocal-6czswbhara-uc.a.run.app`) against the dev server — confirmed 200 OK after the fix, reproduced the 421 before it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3