### PR TITLE
Fix "Missing session ID" by making the MCP transport stateless

### DIFF
--- a/orthocal/asgi.py
+++ b/orthocal/asgi.py
@@ -35,8 +35,19 @@ from mcp_svc.server import mcp
 # against a malicious webpage's JS reaching it through the browser; it
 # doesn't apply to a public HTTPS API with no localhost-only trust boundary,
 # so disabling it here is the correct fix, not a workaround.
+#
+# stateless_http must also be set: the default session manager tracks each
+# session's transport in that process's own memory, but Cloud Run scales
+# this service to multiple instances (maxScale=15, no session affinity
+# configured) with no guarantee a session's follow-up request lands back on
+# the instance that created it -- confirmed via production logs showing
+# several instances each starting their own independent session manager.
+# Both tools are stateless reads, so there's no reason to need session
+# affinity in the first place; stateless_http=True makes every request
+# self-contained instead.
 mcp_application = mcp.streamable_http_app(
     transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
+    stateless_http=True,
 )
 
 


### PR DESCRIPTION
## Summary
- After the 421 fix (#160) deployed, `/mcp` started returning "Bad Request: Missing session ID."
- Cloud Run logs showed several separate container instances each starting their own independent `StreamableHTTP session manager` in short succession -- confirms the SDK's default session manager tracks each session's transport in that process's own memory, but this service scales to multiple instances (`maxScale=15`, no session affinity configured), with no guarantee a session's follow-up request lands back on the instance that created it.
- Both tools (`get_day`, `search_saints`) are stateless reads with no need for server-side session state in the first place, so `stateless_http=True` is the correct fix rather than trying to force session affinity: it makes every request self-contained instead.

## Test plan
- [x] `docker compose run --rm tests` — 135/135 passing
- [x] Verified locally: `tools/call` with no prior `initialize` on the connection and no session ID at all now succeeds (200 OK, correct data) -- confirms statelessness, not just that the old flow still happens to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3