### PR TITLE
Default readings page to LXX2012+WEB; add translation-aware RSS feed

### DIFF
--- a/calendarium/api_urls.py
+++ b/calendarium/api_urls.py
@@ -15,4 +15,5 @@ urlpatterns = [
     path('feed/', cache(ReadingsFeed()), name='rss-feed'),
     path('feed/<cal:cal>/', cache(ReadingsFeed()), name='rss-feed-cal'),
     path('feed/<tradition:tradition>/<cal:cal>/', cache(ReadingsFeed()), name='rss-feed-cal'),
+    path('feed/<tradition:tradition>/<cal:cal>/<translation:translation>/', cache(ReadingsFeed()), name='rss-feed-cal'),
 ]

--- a/calendarium/feeds.py
+++ b/calendarium/feeds.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from django.utils.feedgenerator import Rss201rev2Feed
 
 from . import liturgics
-from .datetools import Calendar, Tradition
+from .datetools import Calendar, Tradition, TRANSLATION_LABELS
 
 
 class WSRssFeed(Rss201rev2Feed):
@@ -27,22 +27,29 @@ class ReadingsFeed(Feed):
     description_template = 'feed_description.html'
     item_categories = categories = 'orthodox', 'christian', 'religion'
 
-    def get_object(self, request, cal=Calendar.Gregorian, tradition=Tradition.Slavic):
-        return {'cal': cal, 'tradition': tradition}
+    def get_object(self, request, cal=Calendar.Gregorian, tradition=Tradition.Slavic, translation=None):
+        return {'cal': cal, 'tradition': tradition, 'translation': translation}
 
     def title(self, obj):
-        return f'Orthodox Daily Readings ({obj["tradition"].title()}, {obj["cal"].title()})'
+        title = f'Orthodox Daily Readings ({obj["tradition"].title()}, {obj["cal"].title()})'
+        if obj['translation']:
+            title += f' [{TRANSLATION_LABELS[obj["translation"]]}]'
+        return title
 
     def description(self, obj):
-        return (f'Daily readings from scripture and the lives of the saints according to the '
-                f'{obj["tradition"].title()} tradition, {obj["cal"].title()} calendar.')
+        description = (f'Daily readings from scripture and the lives of the saints according to the '
+                        f'{obj["tradition"].title()} tradition, {obj["cal"].title()} calendar.')
+        if obj['translation']:
+            description += f' Scripture from the {TRANSLATION_LABELS[obj["translation"]]}.'
+        return description
 
     def items(self, obj):
         now = timezone.localtime()
         start_dt = now - timedelta(days=10)
         for dt in rrule(DAILY, dtstart=start_dt, until=now):
-            day = liturgics.Day(dt.year, dt.month, dt.day, calendar=obj['cal'], tradition=obj['tradition'])
+            day = liturgics.Day(dt.year, dt.month, dt.day, calendar=obj['cal'], tradition=obj['tradition'], translation=obj['translation'])
             day.initialize()
+            day.get_readings(fetch_content=True)
             yield day
 
     def item_pubdate(self, day):

--- a/calendarium/liturgics/day.py
+++ b/calendarium/liturgics/day.py
@@ -140,6 +140,17 @@ class Day:
         return str(self.date)
 
     @cached_property
+    def translation_label(self):
+        """Human-readable label for the Bible translation actually in effect
+        -- resolves the per-language default the same way VerseManager does,
+        since self.translation is often None (meaning "use the default")
+        rather than always holding a concrete value."""
+
+        from bible.models import DEFAULT_TRANSLATIONS
+
+        return datetools.TRANSLATION_LABELS[self.translation or DEFAULT_TRANSLATIONS[self.language]]
+
+    @cached_property
     def summary_title(self):
         """A simplified title that summarizes the day's commemorations."""
 

--- a/calendarium/templates/feed_description.html
+++ b/calendarium/templates/feed_description.html
@@ -35,7 +35,7 @@
 </ul>
 {% endif %}
 
-<h2>Scripture Readings&nbsp;(KJV)</h2>
+<h2>Scripture Readings&nbsp;({{ obj.translation_label }})</h2>
 
 {% for reading in obj.get_readings %}
 <section>
@@ -47,7 +47,7 @@
 	</h3>
 
 	<p>
-	{% for verse in reading.pericope.get_passage %}
+	{% for verse in reading.pericope.passage %}
 		{% if verse.paragraph_start and not forloop.first %}</p><p>{% endif %}
 		<sup>{{ verse.verse }}</sup> {{ verse.content }}
 	{% endfor %}

--- a/calendarium/tests/test_feeds.py
+++ b/calendarium/tests/test_feeds.py
@@ -1,5 +1,7 @@
 import re
 
+from freezegun import freeze_time
+
 from django.test import TestCase
 from django.urls import reverse
 
@@ -42,3 +44,20 @@ class FeedTest(TestCase):
         slavic_title = re.search(r'<title>(.*?)</title>', self.client.get(slavic_url).content.decode('utf-8')).group(1)
         greek_title = re.search(r'<title>(.*?)</title>', self.client.get(greek_url).content.decode('utf-8')).group(1)
         self.assertNotEqual(slavic_title, greek_title)
+
+    @freeze_time('2026-07-25 12:00:00')  # noon UTC stays July 25 in America/Los_Angeles too
+    def test_translation_changes_passage_content(self):
+        """A regression test: the feed's items() didn't pass fetch_content=True
+        to get_readings(), and feed_description.html called the get_passage()
+        method (fresh query, its own kjv-defaulting args) instead of the
+        passage attribute -- so an explicit translation was silently ignored
+        and every feed rendered KJV regardless of what was requested."""
+        kjv_url = reverse('rss-feed-cal', kwargs={'tradition': Tradition.Slavic, 'cal': Calendar.Gregorian})
+        lxx_url = reverse('rss-feed-cal', kwargs={'tradition': Tradition.Slavic, 'cal': Calendar.Gregorian, 'translation': 'lxx2012-web'})
+
+        kjv_body = self.client.get(kjv_url).content.decode('utf-8')
+        lxx_body = self.client.get(lxx_url).content.decode('utf-8')
+
+        self.assertIn('subject unto the higher powers', kjv_body)
+        self.assertIn('in subjection to the higher authorities', lxx_body)
+        self.assertNotIn('subject unto the higher powers', lxx_body)

--- a/calendarium/views.py
+++ b/calendarium/views.py
@@ -12,8 +12,6 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
 
-from bible.models import DEFAULT_TRANSLATIONS
-
 from . import liturgics, models
 from .datetools import Calendar, Tradition, Translation, TRANSLATION_LABELS, cal_session_key, translation_session_key
 
@@ -50,7 +48,7 @@ async def readings_view(request, cal=None, tradition=None, translation=None, yea
         'cal': cal,
         'tradition': tradition,
         'translation': translation,
-        'translation_label': TRANSLATION_LABELS[translation or DEFAULT_TRANSLATIONS[request.LANGUAGE_CODE]],
+        'translation_label': day.translation_label,
         # Only the selectable (English) translations, not every code that can
         # appear in Verse rows -- ro/sr each have one fixed translation with
         # no dropdown, so rccv/srp1865 aren't offered as choices here.
@@ -166,14 +164,18 @@ def remember_translation(request, translation, language):
     session_key = translation_session_key(language)
 
     if translation:
-        if translation != request.session.get(session_key, Translation.KJV):
+        if translation != request.session.get(session_key, Translation.LXX2012WEB):
             request.session[session_key] = translation
 
         # Don't send vary on cookie header when we have an explicit translation.
         # In this case, the session does not actually impact the content.
         request.session.accessed = False
     else:
-        translation = request.session.get(session_key, Translation.KJV)
+        # Only the readings page defaults to the modern translation -- the
+        # API and RSS feeds are unaffected, since neither calls this function;
+        # they resolve translation=None straight through to
+        # bible.models.DEFAULT_TRANSLATIONS['en'] (kjv), unchanged.
+        translation = request.session.get(session_key, Translation.LXX2012WEB)
 
     return translation
 

--- a/orthocal/templates/feeds.html
+++ b/orthocal/templates/feeds.html
@@ -25,6 +25,11 @@
 	<blockquote><a href="{% url "rss-feed-cal" tradition="greek" cal="gregorian" %}">{% fullurl "rss-feed-cal" tradition="greek" cal="gregorian" %}</a></blockquote>
 	<blockquote><a href="{% url "rss-feed-cal" tradition="greek" cal="julian" %}">{% fullurl "rss-feed-cal" tradition="greek" cal="julian" %}</a></blockquote>
 
+	<p>Every RSS feed above reads from the King James Version by default. For the more modern LXX2012+WEB
+	pairing instead, add the translation to the URL:</p>
+
+	<blockquote><a href="{% url "rss-feed-cal" tradition="slavic" cal="gregorian" translation="lxx2012-web" %}">{% fullurl "rss-feed-cal" tradition="slavic" cal="gregorian" translation="lxx2012-web" %}</a></blockquote>
+
 	<h3>iCal</h3>
 
 	<p>An ical feed for the Slavic tradition, new calendar is available at:</p>


### PR DESCRIPTION
## Summary
- The readings/landing page now defaults to the modern LXX2012+WEB pairing instead of KJV. The API and RSS feeds are unaffected -- neither calls `remember_translation`, so `translation=None` still resolves to `kjv` via `bible.models.DEFAULT_TRANSLATIONS` exactly as before.
- Adds a new RSS feed URL, `/api/feed/<tradition>/<cal>/<translation>/` (e.g. `/api/feed/slavic/gregorian/lxx2012-web/`), for subscribing to the modern translation specifically. Linked from the feeds documentation page.
- **Found and fixed a real pre-existing bug** while verifying the new feed: `ReadingsFeed.items()` never passed `fetch_content=True` to `get_readings()`, and `feed_description.html` called `reading.pericope.get_passage` (a method that re-queries fresh with its own `kjv`-defaulting arguments) instead of `.passage` (the cached, correctly-translated attribute) -- so any explicit translation was silently discarded and every feed rendered KJV regardless of what was requested. This had zero test coverage before.
- Adds `Day.translation_label` as a reusable property, replacing a similarly-hardcoded `"(KJV)"` heading in the feed description template and simplifying `readings_view`'s own translation label lookup.

## Test plan
- [x] `docker compose run --rm tests` -- 136/136 passing
- [x] New regression test confirms the two feed URLs actually differ in passage content (not just title/description text) for a known reading
- [x] Manually verified: readings page default now shows modern text with no explicit translation choice; default (KJV) RSS feed unchanged; new translation-parameterized feed shows correct modern text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3