### PR TITLE
Update about page for the new default; fix stale beta badge on calendar

### DIFF
--- a/calendarium/templates/calendar.html
+++ b/calendarium/templates/calendar.html
@@ -24,9 +24,8 @@
 
 	<br>
 
-	<label title="OCA, ROCOR"><input type="radio" name="tradition" value="slavic" {% if tradition == "slavic" %}checked=""{% endif %}>Slavic</label>
-	<label title="Antiochian, Greek Archdiocese"><input type="radio" name="tradition" value="greek" {% if tradition == "greek" %}checked=""{% endif %}>Greek</label>
-	<span class="beta-note">(beta)</span>
+	<label class="tradition-label-with-badge" title="OCA, ROCOR"><input type="radio" name="tradition" value="slavic" {% if tradition == "slavic" %}checked=""{% endif %}>Slavic</label>
+	<label class="tradition-label-with-badge" title="Antiochian, Greek Archdiocese"><input type="radio" name="tradition" value="greek" {% if tradition == "greek" %}checked=""{% endif %}>Greek <span class="status-badge">New</span></label>
 
 	<br>
 

--- a/orthocal/templates/about.html
+++ b/orthocal/templates/about.html
@@ -72,25 +72,26 @@
 	<h2>Scriptures</h2>
 	<p>Because this is open-source and free, the service must use a
 	translation of the Bible that is either public domain or has agreeable
-	license terms. The default translation is the King James Version.
-	While not ideal, many clergy consider this to be one of the
-	best options for Orthodox. Because the rubrics use Septuagint
-	versification, a handful of the Old Testament readings may be incorrect.</p>
-    <p>For readers who want modern English, as well as an Old Testament
-    translated directly from the Septuagint, 
+	license terms. The default translation for the daily readings is
 	<a href="https://en.wikipedia.org/wiki/The_Septuagint_version_of_the_Old_Testament_(Brenton)">LXX2012</a> +
-	<a href="https://en.wikipedia.org/wiki/World_English_Bible">WEB</a> is available.
-    The <a href="https://easternorthodoxbible.org/">Eastern Orthodox Bible (EOB)</a> project began as a
-    revision of the WEB. Both LXX2012 and WEB come from Michael Paul
+	<a href="https://en.wikipedia.org/wiki/World_English_Bible">WEB</a>, a modern-English pairing with
+	an Old Testament translated directly from the Septuagint.
+	The <a href="https://easternorthodoxbible.org/">Eastern Orthodox Bible (EOB)</a> project began as a
+	revision of the WEB. Both LXX2012 and WEB come from Michael Paul
 	Johnson's public-domain modernization work, published through
-    <a href="https://ebible.org/">eBible.org</a>. LXX2012 updates Sir Lancelot Brenton's 1851 translation of
+	<a href="https://ebible.org/">eBible.org</a>. LXX2012 updates Sir Lancelot Brenton's 1851 translation of
 	the Septuagint, so it follows the same versification and Old Testament
 	content&mdash;including the books outside the Protestant
 	canon&mdash;that the lectionary itself is based on. The WEB (World
-    English Bible) is an update of the 1901 American Standard Version, using
-    the Byzantine Majority Text for the New Testament. It is a well-respected,
-    easy-to-read translation without the interpretive biases of translations
-    like the NIV. Both are public domain.</p>
+	English Bible) is an update of the 1901 American Standard Version, using
+	the Byzantine Majority Text for the New Testament. It is a well-respected,
+	easy-to-read translation without the interpretive biases of translations
+	like the NIV. Both are public domain.</p>
+	<p>The King James Version is also available as an alternative on the
+	readings page, and remains the default for the API and RSS feeds. While
+	not ideal, many clergy consider this to be one of the best options for
+	Orthodox. Because the rubrics use Septuagint versification, a handful of
+	the Old Testament readings may be incorrect.</p>
 	<p>Some of the composite readings are taken from the translations of the
 	Archimandrite Ephrem (Lash). His translations can be accessed at
 	<a href="https://github.com/brianglass/anastasis">Anastasis.</a></p>


### PR DESCRIPTION
## Summary
- `about.html`'s Scriptures section now describes LXX2012+WEB as the readings-page default (KJV as the alternative, noting it remains the API/RSS default) -- follow-up to #162.
- Fixes `calendar.html`'s Greek tradition selector, which still used `class="beta-note"` (removed/renamed to `.status-badge` in an earlier session) -- it's been rendering as unstyled plain text `"(beta)"` since then, unlike the readings page which already got the badge treatment. Replaced with the same pattern already used there.

## Test plan
- [x] `docker compose run --rm tests` -- 136/136 passing
- [x] Visually verified the calendar page's Greek badge renders correctly (matches the readings page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3