### PR TITLE
Dormition Fast: remove wine-and-oil floor for lower-ranked feast days

### DIFF
--- a/calendarium/liturgics/day.py
+++ b/calendarium/liturgics/day.py
@@ -785,19 +785,24 @@ class SlavicDay(Day):
                     self.fast_exception -= 1
             case FastLevels.DormitionFast:
                 # Unlike the Apostles' and Nativity fasts, the Dormition Fast
-                # has no rank-based fish exception -- the Typikon's Vigil-rank
-                # fish rule (Ch. 32-33) is scoped to those two fasts only.
+                # has no rank-based exception at all -- the Typikon's
+                # Vigil-rank fish rule (Ch. 32-33) is scoped to those two
+                # fasts only, and no source found extends even a wine-and-oil
+                # floor to a lower-ranked commemoration during Dormition
+                # (confirmed directly against antiochian.org/liturgicday for
+                # 8/13, 2026: Leavetaking of Transfiguration, feast_level 4,
+                # is listed as a full abstention day -- no wine or oil).
                 # Every source checked treats Dormition as strict as Great
-                # Lent with a single dated exception: the Transfiguration
-                # itself (Aug 6, feast_level 8, "Major feast Lord"). Cap
+                # Lent with exactly one dated exception: the Transfiguration
+                # itself (Aug 6, feast_level 8, "Major feast Lord"). Zero out
                 # anything baked onto a lower-ranked row -- e.g. a Vigil-rank
-                # saint's own commemoration, which grants no such exception
-                # here even though it would during the other two fasts --
-                # down to wine-and-oil.
-                if self.feast_level < 7 and self.fast_exception > 1:
-                    self.fast_exception = 1
+                # saint's own commemoration, which would grant an exception
+                # during the other two fasts but not here.
+                if self.feast_level < 7 and self.fast_exception > 0:
+                    self.fast_exception = 0
 
-                # Allow wine and oil on weekends during the Dormition fast
+                # Allow wine and oil on weekends during the Dormition fast --
+                # a day-of-week exception, independent of feast rank.
                 if self.weekday in (Weekday.Sunday, Weekday.Saturday) and self.fast_exception == 0:
                     self.fast_exception += 1
             case FastLevels.ApostlesFast | FastLevels.NativityFast:
@@ -853,19 +858,24 @@ class GreekDay(Day):
                     self.fast_exception -= 1
             case FastLevels.DormitionFast:
                 # Unlike the Apostles' and Nativity fasts, the Dormition Fast
-                # has no rank-based fish exception -- the Typikon's Vigil-rank
-                # fish rule (Ch. 32-33) is scoped to those two fasts only.
+                # has no rank-based exception at all -- the Typikon's
+                # Vigil-rank fish rule (Ch. 32-33) is scoped to those two
+                # fasts only, and no source found extends even a wine-and-oil
+                # floor to a lower-ranked commemoration during Dormition
+                # (confirmed directly against antiochian.org/liturgicday for
+                # 8/13, 2026: Leavetaking of Transfiguration, feast_level 4,
+                # is listed as a full abstention day -- no wine or oil).
                 # Every source checked treats Dormition as strict as Great
-                # Lent with a single dated exception: the Transfiguration
-                # itself (Aug 6, feast_level 8, "Major feast Lord"). Cap
+                # Lent with exactly one dated exception: the Transfiguration
+                # itself (Aug 6, feast_level 8, "Major feast Lord"). Zero out
                 # anything baked onto a lower-ranked row -- e.g. a Vigil-rank
-                # saint's own commemoration, which grants no such exception
-                # here even though it would during the other two fasts --
-                # down to wine-and-oil.
-                if self.feast_level < 7 and self.fast_exception > 1:
-                    self.fast_exception = 1
+                # saint's own commemoration, which would grant an exception
+                # during the other two fasts but not here.
+                if self.feast_level < 7 and self.fast_exception > 0:
+                    self.fast_exception = 0
 
-                # Allow wine and oil on weekends during the Dormition fast
+                # Allow wine and oil on weekends during the Dormition fast --
+                # a day-of-week exception, independent of feast rank.
                 if self.weekday in (Weekday.Sunday, Weekday.Saturday) and self.fast_exception == 0:
                     self.fast_exception += 1
             case FastLevels.ApostlesFast:

--- a/calendarium/tests/test_liturgics.py
+++ b/calendarium/tests/test_liturgics.py
@@ -370,9 +370,9 @@ class TestGreekFasting(TestCase):
 
         Aug 9 (St Herman of Alaska's Vigil-rank feast, Slavic tradition)
         needs no exclusion here: see
-        test_dormition_fast_grants_no_rank_based_fish_exception below for
-        why both traditions correctly agree at plain wine-and-oil despite
-        Slavic's Vigil rank."""
+        test_dormition_fast_grants_no_rank_based_exception below for why
+        both traditions correctly agree at plain wine-and-oil (from the
+        weekend rule, not Herman's rank) despite Slavic's Vigil rank."""
 
         dates = (
             [date(2026, 4, d) for d in range(5, 13)]        # Holy Week
@@ -390,11 +390,11 @@ class TestGreekFasting(TestCase):
                 self.assertEqual(slavic.fast_level_desc, greek.fast_level_desc)
                 self.assertEqual(slavic.fast_exception_desc, greek.fast_exception_desc)
 
-    async def test_dormition_fast_grants_no_rank_based_fish_exception(self):
+    async def test_dormition_fast_grants_no_rank_based_exception(self):
         """Regression test for a data bug reported directly against
         production: Aug 9, 2026 (St Herman of Alaska's Vigil-rank feast)
         showed a fish allowance, contradicting antiochian.org and
-        goarch.org (both show wine-and-oil only).
+        goarch.org (both show no such thing).
 
         The root cause wasn't bad data on any one row -- Herman's
         Vigil rank (feast_level=5) is itself correct, confirmed against
@@ -403,31 +403,39 @@ class TestGreekFasting(TestCase):
         fish exception (Ch. 32-33) is scoped to the Apostles' and Nativity
         fasts only -- it doesn't exist for the Dormition Fast, which every
         source treats as strict throughout except for one dated exception,
-        the Transfiguration itself (Aug 6). So this is fixed in
-        _apply_fasting_adjustments (the feast_level < 7 cap below
-        Transfiguration's own rank), not by editing any row's stored
-        fast_exception -- the same underlying data (Vigil rank included)
-        now produces the correct outcome for both traditions.
+        the Transfiguration itself (Aug 6).
 
-        Aug 13 (Leavetaking of the Transfiguration, feast_level=4) is
-        caught by the same general rule for the same reason: no source
-        checked lists it as a second fish day -- every one names only
-        Aug 6."""
+        First fix attempt capped any rank-based exception down to
+        wine-and-oil rather than removing it outright -- also wrong,
+        confirmed by checking antiochian.org/liturgicday/4644 directly:
+        Aug 13, 2026 (Leavetaking of the Transfiguration, feast_level=4,
+        a Thursday with no weekend exception in play) is listed there as a
+        full abstention day, no wine or oil either. Dormition grants
+        *no* exception at all from feast rank alone -- only the
+        Transfiguration's own date, and the separate weekend allowance,
+        are real exceptions. Aug 9, 2026 happens to be a Sunday, so it
+        still shows wine-and-oil -- via the weekend rule, not Herman's
+        rank -- which is why both cases below need different expected
+        values despite both starting from a similar-looking Vigil/
+        Polyeleos rank."""
 
-        cases = [
-            (8, 9, 'Herman of Alaska Vigil feast'),
-            (8, 13, 'Leavetaking of the Transfiguration'),
-        ]
+        # Aug 9, 2026 is a Sunday: wine-and-oil here comes from the
+        # weekend rule, not from Herman's Vigil rank.
+        slavic_herman = liturgics.Day(2026, 8, 9, tradition=Tradition.Slavic)
+        greek_herman = liturgics.Day(2026, 8, 9, tradition=Tradition.Greek)
+        await slavic_herman.ainitialize()
+        await greek_herman.ainitialize()
+        self.assertEqual(slavic_herman.fast_exception_desc, 'Wine and Oil are Allowed')
+        self.assertEqual(greek_herman.fast_exception_desc, 'Wine and Oil are Allowed')
 
-        for month, day, label in cases:
-            with self.subTest(label):
-                slavic = liturgics.Day(2026, month, day, tradition=Tradition.Slavic)
-                greek = liturgics.Day(2026, month, day, tradition=Tradition.Greek)
-                await slavic.ainitialize()
-                await greek.ainitialize()
-
-                self.assertEqual(slavic.fast_exception_desc, 'Wine and Oil are Allowed')
-                self.assertEqual(greek.fast_exception_desc, 'Wine and Oil are Allowed')
+        # Aug 13, 2026 is a Thursday: no weekend rule, no rank-based
+        # exception -- full abstention, matching antiochian.org.
+        slavic_leavetaking = liturgics.Day(2026, 8, 13, tradition=Tradition.Slavic)
+        greek_leavetaking = liturgics.Day(2026, 8, 13, tradition=Tradition.Greek)
+        await slavic_leavetaking.ainitialize()
+        await greek_leavetaking.ainitialize()
+        self.assertEqual(slavic_leavetaking.fast_exception_desc, '')
+        self.assertEqual(greek_leavetaking.fast_exception_desc, '')
 
         # Transfiguration itself (Aug 6, feast_level=8) is the one dated
         # exception and must be unaffected by the cap.


### PR DESCRIPTION
## Summary
- A previous fix (Herman of Alaska's Vigil-rank fish allowance) capped any inherited `fast_exception` down to wine-and-oil for `feast_level < 7` during the Dormition Fast, rather than removing the exception outright.
- Checked antiochian.org/liturgicday/4644 directly: Aug 13, 2026 (Leavetaking of the Transfiguration, feast_level=4, a Thursday with no weekend exception in play) is listed as a full abstention day -- no wine or oil either.
- Confirms Dormition grants no rank-based exception at all; the only real exceptions are the Transfiguration's own date (Aug 6) and the separate weekend allowance. Both `SlavicDay` and `GreekDay` now zero out the exception instead of flooring it at wine-and-oil.

This branch was cherry-picked from `feast-name-day-commemoration-audit` after that branch's PR (#165) was already merged -- this commit was pushed to the feature branch after the merge, so it needed its own PR.

## Test plan
- [x] 142/142 tests pass, rebuilt fresh against this branch
- [x] Verified live: `/readings/slavic/gregorian/2026/8/13/` now shows "Abstain from meat, fish, dairy, eggs, wine, and oil" -- matching Antiochian's page exactly
- [x] Confirmed Transfiguration itself (Aug 6) and weekend dates (Aug 1/2/8/9) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3