### PR TITLE
Scale page-nav content before wrapping; fix scrollbar-caused centering offset

### DIFF
--- a/orthocal/static/main.css
+++ b/orthocal/static/main.css
@@ -1,8 +1,12 @@
 html {
     font-size: 20px;
     font-family: 'EB Garamond', Garamond, 'Times New Roman', Georgia, serif;
-    /* Prevent page shifting when scrollbar disappears on short pages */
-    overflow-y: scroll;
+    /* Reserve the scrollbar's gutter on both edges so centered content
+       doesn't shift left when a page happens to be short enough not to
+       scroll (overflow-y:scroll alone reserves the gutter on the right
+       only, throwing centered content off by half a scrollbar-width). */
+    overflow-y: auto;
+    scrollbar-gutter: stable both-edges;
 }
 body {
     margin: 0;
@@ -155,6 +159,9 @@ h1, h2, h3, h4 {
     .topbar-inner > header {
         white-space: normal;
     }
+    .day-nav, .toggle-row {
+        flex-wrap: wrap;
+    }
 }
 
 /* Page-specific navigation (day/month nav, tradition/calendar toggles) --
@@ -165,17 +172,18 @@ nav.page-nav {
     width: 75%;
     margin: 0 auto;
     padding: 0.4em 0 0.5em 0;
+    font-size: clamp(0.6em, calc(3cqw), 1em);
 }
 .page-nav-row {
     display: flex;
     align-items: center;
     justify-content: space-between;
     flex-wrap: wrap;
-    gap: 0.5em 1.5em;
+    gap: 0.5rem 1.5rem;
 }
 .day-nav {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
 }
 nav.page-nav a:link, nav.page-nav a:visited {
     text-decoration: none;
@@ -349,8 +357,8 @@ label {
 	display: flex;
 	justify-content: flex-end;
 	align-items: center;
-	gap: 1em;
-	flex-wrap: wrap;
+	gap: 1rem;
+	flex-wrap: nowrap;
 }
 .segmented-control {
 	display: inline-flex;


### PR DESCRIPTION
## Summary
- The day-nav links (Previous/Today/Next) and the tradition/calendar toggles now shrink via the same container-query technique used for the site title, instead of wrapping at almost any narrow width. They only fall back to wrapping below 400px, once the smallest scaled font no longer fits on one line.
- Fixes `main#orthocal`'s centering being off by ~15px (half a scrollbar-width) on narrow viewports. The page previously forced a permanent `overflow-y: scroll`, which reserves the scrollbar's gutter on the right edge only, throwing off `margin: 0 auto` centering. Switched to `scrollbar-gutter: stable both-edges`, which reserves the gutter symmetrically (still preventing layout shift on short pages, the original goal) while keeping content centered.

## Test plan
- [x] `docker compose run --rm tests` — 142 tests pass
- [x] Verified page-nav scaling/no-overflow across a swept range of container widths in Chrome
- [x] Verified centering fix at a real (non-default) browser window width — confirmed symmetric left/right gaps for `main#orthocal`, the header content, and `.readings-columns`
- [ ] Author to verify on an actual Android phone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3