### PR TITLE
Add two Greek-tradition commemorations missing from Aug 12

### DIFF
--- a/fixtures/commemorations.json
+++ b/fixtures/commemorations.json
@@ -13384,6 +13384,22 @@
   }
 },
 {
+  "model": "commemorations.saint",
+  "pk": 7108,
+  "fields": {
+    "name": "Sergios, Stephen and Kastor",
+    "full_name": null
+  }
+},
+{
+  "model": "commemorations.saint",
+  "pk": 7109,
+  "fields": {
+    "name": "Palamon, Elder of Pachomius",
+    "full_name": null
+  }
+},
+{
   "model": "commemorations.daycommemoration",
   "pk": 5209,
   "fields": {
@@ -40980,6 +40996,38 @@
     "new_style": false,
     "day_native": true,
     "ordering": 2,
+    "tradition": "greek"
+  }
+},
+{
+  "model": "commemorations.daycommemoration",
+  "pk": 7247,
+  "fields": {
+    "day": 660,
+    "saint": 7108,
+    "title": "Sergios, Stephen and Kastor",
+    "story": null,
+    "rank": 0,
+    "high_rank": false,
+    "new_style": false,
+    "day_native": true,
+    "ordering": 2,
+    "tradition": "greek"
+  }
+},
+{
+  "model": "commemorations.daycommemoration",
+  "pk": 7248,
+  "fields": {
+    "day": 660,
+    "saint": 7109,
+    "title": "Palamon, Elder of Pachomius",
+    "story": null,
+    "rank": 0,
+    "high_rank": false,
+    "new_style": false,
+    "day_native": true,
+    "ordering": 3,
     "tradition": "greek"
   }
 }


### PR DESCRIPTION
## Summary
The Greek tradition was showing only 3 commemorations for August 12 when it should show 5. Root cause: antiochian.org's source data for this date is one comma-separated paragraph --

> "The Holy Martyrs Photius and Anicetus of Nicomedia, Sergios, Stephen and Kastor, Palamon, Elder of Saint Pachomius the Great, Soldier-martyrs of Crete, Afterfeast of the Transfiguration of our Lord and Savior Jesus Christ"

-- and correctly segmenting it requires knowing that "Sergios, Stephen and Kastor" is its own single commemoration (not a continuation of the Photius/Anicetus entry, and not three separate people). Only "Soldier-martyrs of Crete" made it into the existing harvested data; "Sergios, Stephen and Kastor" and "Palamon, Elder of Pachomius" were silently dropped somewhere in the original ingestion.

Confirmed the correct segmentation against **goarch.org/chapel**'s Aug 12 saints list, which shows the day's commemorations as separate bullets rather than one paragraph. goarch.org blocks scripted HTTP clients (Cloudflare bot management -- see `docs/greek-weekday-drift.md`), so this required a real browser session rather than `curl`/`WebFetch`.

Added both as `tradition='greek'`, `day_native=true`, `story=null` -- the same shape as the pre-existing `Soldier-martyrs of Crete` row from the same harvest -- with `ordering` 2 and 3, which exactly fills the gap between the existing ordering 0/1/4 rows for this day.

## Test plan
- [x] `docker compose run --rm --build tests` -- 145 tests pass
- [x] `liturgics.Day(2026, 8, 12, tradition='greek').saints` now returns all 5 commemorations in the correct order; `tradition='slavic'` unaffected (still 2)
- [x] Verified on the live dev site: both new entries render as plain (non-linked) text under Commemorations, consistent with the empty-story fix from #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3