### PR TITLE
Search UX polish and more fragmented saint-identity merges

### DIFF
--- a/commemorations/templates/saint_search.html
+++ b/commemorations/templates/saint_search.html
@@ -10,8 +10,7 @@
 	<h2>Search for a Saint</h2>
 
 	<form method="get" action="{% url "saint-search" %}" class="saint-search-form">
-		<label for="saint-search-q">Name</label>
-		<input type="text" id="saint-search-q" name="q" value="{{ query }}" placeholder="e.g. Seraphim, Nicholas, Xenia" autofocus>
+		<input type="text" name="q" value="{{ query }}" placeholder="e.g. Seraphim, Nicholas, Xenia" aria-label="Saint name" autofocus>
 		<button type="submit">Search</button>
 	</form>
 

--- a/commemorations/tests.py
+++ b/commemorations/tests.py
@@ -24,9 +24,11 @@ class SaintSearchTransliterationTestCase(TestCase):
 
     def setUp(self):
         # Fixture loading bypasses Saint.save() (same reason `slug` needs
-        # its own backfill command, see the model), so normalized_name is
-        # blank on freshly test-loaded fixture data unless backfilled here
-        # -- mirrors what the Dockerfile does for a real deployment.
+        # its own backfill command, see the model), so normalized_name and
+        # slug are blank on freshly test-loaded fixture data unless
+        # backfilled here -- mirrors what the Dockerfile does for a real
+        # deployment.
+        call_command('backfill_saint_slugs')
         call_command('backfill_saint_normalized_names')
 
     def test_greek_spelling_finds_latin_spelled_saint(self):
@@ -34,3 +36,8 @@ class SaintSearchTransliterationTestCase(TestCase):
 
         names = [saint.display_name for saint in response.context['results']]
         self.assertIn('St Athanasius the Great, patriarch of Alexandria', names)
+
+    def test_single_result_redirects_to_detail_page(self):
+        response = self.client.get(reverse('saint-search'), {'q': 'myra Nicholas'})
+
+        self.assertRedirects(response, reverse('saint-detail', args=['our-father-among-the-saints-nicholas-the-wonderworker-archbishop-of-myra-345-5-9']))

--- a/commemorations/views.py
+++ b/commemorations/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404, redirect, render
 
 from calendarium.liturgics.day import _has_story
 
@@ -46,6 +46,11 @@ def search_view(request):
                 results.append(_attach_display_name(saint))
                 if len(results) >= 50:
                     break
+
+        # A single match is unambiguous -- skip straight to their page
+        # rather than making the user click through a one-item list.
+        if len(results) == 1:
+            return redirect('saint-detail', results[0].slug)
 
     return render(request, 'saint_search.html', context={
         'query': query,

--- a/fixtures/commemorations.json
+++ b/fixtures/commemorations.json
@@ -7409,14 +7409,6 @@
 },
 {
   "model": "commemorations.saint",
-  "pk": 6109,
-  "fields": {
-    "name": "St Maximos the Confessor (662)",
-    "full_name": "St Maximos the Confessor (662)"
-  }
-},
-{
-  "model": "commemorations.saint",
   "pk": 6110,
   "fields": {
     "name": "Holy Martyr Hippolytus of Rome and 18 Martyrs with him (258)",
@@ -47990,7 +47982,7 @@
   "pk": 986,
   "fields": {
     "commemoration": 6239,
-    "saint": 6109,
+    "saint": 5132,
     "order": 1
   }
 },

--- a/orthocal/static/main.css
+++ b/orthocal/static/main.css
@@ -551,14 +551,12 @@ table.month td.sat:hover
 
 .saint-search-form {
 	display: flex;
+	flex-wrap: wrap;
 	align-items: center;
 	justify-content: center;
 	gap: 0.6em;
 	margin: 1.5em 0 2em 0;
 	text-indent: 0 !important;
-}
-.saint-search-form label {
-	font-size: 1em;
 }
 .saint-search-form input[type="text"] {
 	font-family: inherit;
@@ -567,6 +565,7 @@ table.month td.sat:hover
 	border: 1px solid #bbb;
 	border-radius: 3px;
 	width: 16em;
+	max-width: 100%;
 }
 .saint-search-form button {
 	font-family: inherit;


### PR DESCRIPTION
## Summary

Follow-up to #175, continuing to use the saint search feature to find and fix data-quality issues.

- Search form now wraps at narrow widths instead of clipping the label/input/button, and drops the redundant "Name" label.
- A single search result now redirects straight to that saint's detail page instead of showing a one-item results list.
- Merge more fragmented saint identities found via search: Xenia of St Petersburg's canonization entry, three unlinked Archangel Gabriel entries, and Maximus the Confessor's two entries (abbamoses's own text on the shorter one explicitly cross-references "He is also commemorated on January 21" — confirmed both are the same repose account told at different lengths before merging).
- Fix hamburger-menu dropdown clipping on short pages, and widen the nav breakpoint whose safety margin had shrunk after adding "saints" to the nav.

## Test plan

- [x] Full test suite passes (149 tests) against a from-scratch image build
- [x] Manually verified in-browser: search form wrapping, single-result redirect, each data merge via the saint detail page, hamburger menu (confirmed in both Chrome and Firefox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3