### PR TITLE
Match Slavic -ovich/-ovitch surname spelling variants in saint search

### DIFF
--- a/commemorations/tests.py
+++ b/commemorations/tests.py
@@ -14,6 +14,7 @@ class NormalizeTransliterationTestCase(TestCase):
             ('Symeon', 'Simeon'),
             ('Cosmas', 'Kosmas'),
             ('Isaac', 'Isaak'),
+            ('Maximovich', 'Maximovitch'),
         ]
         for latin, greek in pairs:
             self.assertEqual(normalize_transliteration(latin), normalize_transliteration(greek))
@@ -36,6 +37,17 @@ class SaintSearchTransliterationTestCase(TestCase):
 
         names = [saint.display_name for saint in response.context['results']]
         self.assertIn('St Athanasius the Great, patriarch of Alexandria', names)
+
+    def test_vitch_spelling_finds_vich_spelled_saint(self):
+        # A single story-bearing match -- the other "Maximovitch" (Metr. of
+        # Tobolsk) has no story, so it's excluded and this redirects
+        # straight to the one remaining detail page.
+        response = self.client.get(reverse('saint-search'), {'q': 'John Maximovitch'})
+
+        self.assertRedirects(response, reverse(
+            'saint-detail',
+            args=['st-john-maximovich-archbishop-of-shanghai-and-san-francisco-1966-june-19-oc-7-2'],
+        ))
 
     def test_single_result_redirects_to_detail_page(self):
         response = self.client.get(reverse('saint-search'), {'q': 'myra Nicholas'})

--- a/commemorations/transliteration.py
+++ b/commemorations/transliteration.py
@@ -4,15 +4,18 @@ import re
 def normalize_transliteration(text):
     """Canonicalize common Greek/Latin transliteration spelling variants
     (e.g. "Athanasios" vs "Athanasius", "Dionysios" vs "Dionysius", "Cosmas"
-    vs "Kosmas") to the same form, so name search can match across them.
-    Not a general phonetic algorithm -- just the specific substitution
-    patterns found in this corpus, where names harvested from Greek-tradition
-    sources and names carried over from the older Slavic/abbamoses corpus
-    ended up using different transliteration conventions for the same
-    underlying name."""
+    vs "Kosmas") and Slavic surname transliteration variants (e.g.
+    "Maximovitch" vs "Maximovich" -- older English convention rendered the
+    "-ovich" patronymic ending as "-ovitch") to the same form, so name
+    search can match across them. Not a general phonetic algorithm -- just
+    the specific substitution patterns found in this corpus, where names
+    harvested from Greek-tradition sources and names carried over from the
+    older Slavic/abbamoses corpus ended up using different transliteration
+    conventions for the same underlying name."""
 
     text = text.lower()
     text = re.sub(r'c(?!h)', 'k', text)
     text = re.sub(r'y', 'i', text)
     text = re.sub(r'os\b', 'us', text)
+    text = re.sub(r'vitch\b', 'vich', text)
     return text


### PR DESCRIPTION
## Summary

Follow-up to #175/#176. A search for "John Maximovitch" returned nothing, even though that's an exact substring of an existing saint's name in our data ("St John Maximovitch, Metropolitan of Tobolsk") -- turned out to be two compounding issues:

- The actual exact-spelling match has no story, so it's correctly excluded by the story-less-result filter from #176.
- The saint people are actually looking for -- St John of Shanghai and San Francisco, a much more famous 20th-century saint who happens to share the same family surname (they're distantly related) -- is spelled "Maximovich" (no "t") in our data, and our transliteration matching didn't cover this pattern.

Added a `vitch` -> `vich` rule to `normalize_transliteration`, alongside the existing Greek rules -- older English convention sometimes rendered the Slavic "-ovich" patronymic ending as "-ovitch". Confirmed via a corpus survey that this is a narrow, low-risk addition: only this one name pair uses either spelling currently.

## Test plan

- [x] Full test suite passes (150 tests) against a from-scratch image build
- [x] Manually verified in-browser: searching "John Maximovitch" now redirects straight to St John of Shanghai and San Francisco's page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3