### PR TITLE
Reject GET on /mcp instead of holding an unused SSE stream open

### DIFF
--- a/orthocal/asgi.py
+++ b/orthocal/asgi.py
@@ -51,8 +51,35 @@ mcp_application = mcp.streamable_http_app(
 )
 
 
+async def _reject_get(send):
+    """Neither of orthocal's MCP tools ever needs to push an unsolicited
+    message to a client, so the streamable-http transport's optional GET/SSE
+    channel serves no purpose here -- but the SDK holds it open indefinitely
+    waiting for a server-initiated message that will never come, and Cloud
+    Run only closes it at the request timeout (20s). That turned into the
+    single largest cost driver on this service: a flood of GET requests each
+    billed for a full 20s of held-open compute. Rejecting GET here, before it
+    reaches the MCP app, costs a few milliseconds instead."""
+
+    await send({
+        'type': 'http.response.start',
+        'status': 405,
+        'headers': [
+            (b'allow', b'POST, DELETE'),
+            (b'content-type', b'text/plain'),
+        ],
+    })
+    await send({
+        'type': 'http.response.body',
+        'body': b'Method Not Allowed',
+    })
+
+
 async def application(scope, receive, send):
-    if scope['type'] == 'lifespan' or (scope['type'] == 'http' and scope['path'].startswith('/mcp')):
+    is_mcp_path = scope['type'] == 'http' and scope['path'].startswith('/mcp')
+    if is_mcp_path and scope['method'] == 'GET':
+        await _reject_get(send)
+    elif scope['type'] == 'lifespan' or is_mcp_path:
         await mcp_application(scope, receive, send)
     else:
         await django_application(scope, receive, send)


### PR DESCRIPTION
## Summary
- Investigated an unexpectedly large Cloud Run bill by pulling request logs/metrics for the `orthocal` service. `/mcp` traffic jumped ~50x starting Aug 11 (from a few hundred/day to 4,300-4,700/day), driven entirely by GET requests from `claude-code/2.1.224 (cli)` and `python-httpx` clients across hundreds of distinct Google-owned IPs.
- Every GET to `/mcp` opens the streamable-http transport's optional SSE channel and holds it open indefinitely waiting for a server-push message. Neither of orthocal's tools (`get_day`, `search_saints`) ever sends one, so the stream just sits there until Cloud Run kills it at the 20s request timeout — confirmed via logs: GET latency was pinned at ~21.0s (avg=median=max), vs ~8ms for POST (the actual tool calls). That's the single largest cost driver on this service right now.
- Fix: reject GET on `/mcp*` at the ASGI dispatch level in `orthocal/asgi.py`, before it ever reaches the MCP app. POST (and DELETE) pass through unchanged.

## Test plan
- [x] `docker compose run --rm tests` — 152 tests pass
- [x] Manually verified locally: `GET /mcp` → `405` in ~6ms (was previously a held-open 21s stream); `POST /mcp` `initialize` and a `tools/call` (`search_saints`) both still return `200` and correct results, unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3