### PR TITLE
Revive the parked parchment-texture experiment, retinted to match

### DIFF
--- a/orthocal/static/main.css
+++ b/orthocal/static/main.css
@@ -5,7 +5,12 @@ html {
 }
 body {
     margin: 0;
-    background: linear-gradient(to bottom, #fcfaf6, #f8f4ed 33%);
+    background-color: #fbf8f4;
+    background-image:
+        url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI1MTIiIGhlaWdodD0iNTEyIj4KICA8ZmlsdGVyIGlkPSJncmFpbiIgeD0iMCIgeT0iMCIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSI+CiAgICA8ZmVUdXJidWxlbmNlIHR5cGU9ImZyYWN0YWxOb2lzZSIgYmFzZUZyZXF1ZW5jeT0iMC4wMTgiIG51bU9jdGF2ZXM9IjQiIHNlZWQ9IjExIiBzdGl0Y2hUaWxlcz0ic3RpdGNoIiByZXN1bHQ9Im5vaXNlIi8+CiAgICA8ZmVDb2xvck1hdHJpeCBpbj0ibm9pc2UiIHR5cGU9Im1hdHJpeCIKICAgICAgdmFsdWVzPSIwIDAgMCAwIDAuNQogICAgICAgICAgICAgIDAgMCAwIDAgMC40MTcKICAgICAgICAgICAgICAwIDAgMCAwIDAuMjUKICAgICAgICAgICAgICAwIDAgMCAwLjQgMCIvPgogIDwvZmlsdGVyPgogIDxmaWx0ZXIgaWQ9ImJsb3RjaCIgeD0iMCIgeT0iMCIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSI+CiAgICA8ZmVUdXJidWxlbmNlIHR5cGU9ImZyYWN0YWxOb2lzZSIgYmFzZUZyZXF1ZW5jeT0iMC4wMDQgMC4wMDUiIG51bU9jdGF2ZXM9IjMiIHNlZWQ9IjQiIHN0aXRjaFRpbGVzPSJzdGl0Y2giIHJlc3VsdD0iYmlnIi8+CiAgICA8ZmVDb2xvck1hdHJpeCBpbj0iYmlnIiB0eXBlPSJtYXRyaXgiCiAgICAgIHZhbHVlcz0iMCAwIDAgMCAwLjUKICAgICAgICAgICAgICAwIDAgMCAwIDAuNDA3CiAgICAgICAgICAgICAgMCAwIDAgMCAwLjIyCiAgICAgICAgICAgICAgMCAwIDAgMC42IDAiIHJlc3VsdD0iYmlnVGludCIvPgogICAgPGZlQ29tcG9uZW50VHJhbnNmZXIgaW49ImJpZ1RpbnQiPgogICAgICA8ZmVGdW5jQSB0eXBlPSJnYW1tYSIgYW1wbGl0dWRlPSIxIiBleHBvbmVudD0iMy4yIiBvZmZzZXQ9IjAiLz4KICAgIDwvZmVDb21wb25lbnRUcmFuc2Zlcj4KICA8L2ZpbHRlcj4KICA8cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWx0ZXI9InVybCgjYmxvdGNoKSIgb3BhY2l0eT0iMC40NSIvPgogIDxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbHRlcj0idXJsKCNncmFpbikiIG9wYWNpdHk9IjAuMzIiLz4KPC9zdmc+Cg=="),
+        linear-gradient(to bottom, #fcfaf6, #fbf8f4 33%);
+    background-repeat: repeat, no-repeat;
+    background-size: auto, 100% 100%;
     overflow-x: hidden;
     /* Setting only overflow-x makes the UA compute overflow-y as auto
        rather than visible, turning body into a clipping context -- on a
@@ -258,7 +263,7 @@ main#orthocal > header::before {
        hidden clips the excess, so precision here doesn't matter. */
     left: -100vmax;
     right: -100vmax;
-    background: linear-gradient(to bottom, #f5f0e6, #f4eee1);
+    background: linear-gradient(to bottom, rgba(238, 229, 212, 0.3), rgba(237, 227, 206, 0.3));
     border-bottom: 1px solid #bbb3a0;
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
     z-index: -1;

--- a/orthocal/static/main.css
+++ b/orthocal/static/main.css
@@ -5,7 +5,7 @@ html {
 }
 body {
     margin: 0;
-    background: linear-gradient(to bottom, #fcfaf6, #f8f5ed 33%);
+    background: linear-gradient(to bottom, #fcfaf6, #f8f4ed 33%);
     overflow-x: hidden;
     /* Setting only overflow-x makes the UA compute overflow-y as auto
        rather than visible, turning body into a clipping context -- on a
@@ -36,7 +36,7 @@ h1, h2, h3, h4 {
 
 /* Site title and navigation */
 .topbar {
-    background-color: #fdfbf5;
+    background-color: #fdfaf5;
     border-bottom: 1px solid #bbb3a0;
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
     container-type: inline-size;
@@ -144,7 +144,7 @@ h1, h2, h3, h4 {
         gap: 0;
         box-sizing: border-box;
         width: 12em;
-        background-color: #fdfbf5;
+        background-color: #fdfaf5;
         border: 1px solid #bbb3a0;
         box-shadow: -2px 3px 6px rgba(0, 0, 0, 0.15);
         z-index: 20;
@@ -258,7 +258,7 @@ main#orthocal > header::before {
        hidden clips the excess, so precision here doesn't matter. */
     left: -100vmax;
     right: -100vmax;
-    background: linear-gradient(to bottom, #f5f1e6, #f4eee1);
+    background: linear-gradient(to bottom, #f5f0e6, #f4eee1);
     border-bottom: 1px solid #bbb3a0;
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
     z-index: -1;
@@ -467,15 +467,15 @@ table.month td {
 	border: 1px solid #d4cfc4;
 	font-size: 0.75em;
 	vertical-align: top;
-	background-color: #f3f1ea;
+	background-color: #eee9e0;
 	text-align: left;
     width: 14.28%;
 }
 table.month td.fast {
-	background-color: #e7e5de;
+	background-color: #dfd9cd;
 }
 table.month td.fast:hover {
-	background-color: #e2dfd7 !important;
+	background-color: #dbd4c5 !important;
 }
 table.month td.noday {
 	border: 0;
@@ -488,7 +488,7 @@ table.month tr td p {
 }
 table.month tr th {
 	text-align: center;
-	color: #8a8370;
+	color: #756e5f;
 }
 table.month tr:first-child th {
 	font-size: 1.5em;
@@ -561,7 +561,7 @@ table.month td.thu:hover,
 table.month td.fri:hover,
 table.month td.sat:hover
 {
-	background-color: #e7e5de;
+	background-color: #e6e1d5;
     cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
Stacked on #181 (base branch: `calendar-color-coordination`) since this builds directly on that hue-unification work -- rebase onto `main` once #181 merges.

- Dug up the SVG noise-texture work from the parked `parchment-texture-experiment` branch (two `feTurbulence` layers: low-frequency for soft blotches, higher-frequency for fine grain) and adapted it to the current hue-unified palette instead of the old flat `#fdfbf5` scheme it was built against.
- Retinted the noise filters' color-matrix values from their original ~34-36° hue onto this palette's 40°.
- Removed the SVG's own opaque base rect so it layers *over* the current body gradient instead of replacing it.
- The date-section panel's fill is now a semi-transparent tint over the texture rather than an opaque gradient, so the texture shows through there too.
- Topbar stays flat, unchanged -- matches the original experiment's own decision to leave it alone.
- Lightened the overall background and bumped the texture's opacity a notch so the grain doesn't wash out against the lighter base.

## Test plan
- [x] Verified visually in-browser: date section, readings-columns area, and calendar page all checked for texture visibility and color balance across several iterations
- [ ] Full test suite -- CSS-only, no behavioral impact; not run locally, CI will cover it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3