### PR TITLE
Link the Cyril/Methodius joint commemoration to their real Saint rows

### DIFF
--- a/fixtures/commemorations.json
+++ b/fixtures/commemorations.json
@@ -3129,14 +3129,6 @@
 },
 {
   "model": "commemorations.saint",
-  "pk": 5538,
-  "fields": {
-    "name": "Holy Equals-to-the-Apostles Methodius (885) and Cyril (869), first teachers of the Slavs",
-    "full_name": "Holy Equals-to-the-Apostles Methodius (885) and Cyril (869), first teachers of the Slavs"
-  }
-},
-{
-  "model": "commemorations.saint",
   "pk": 5539,
   "fields": {
     "name": "Holy Equals-to-the-Apostles Emperor Constantine (337) and Helen, his mother (327)",
@@ -42910,8 +42902,17 @@
   "pk": 426,
   "fields": {
     "commemoration": 5667,
-    "saint": 5538,
+    "saint": 5224,
     "order": 1
+  }
+},
+{
+  "model": "commemorations.daycommemorationsaint",
+  "pk": 1730,
+  "fields": {
+    "commemoration": 5667,
+    "saint": 5167,
+    "order": 2
   }
 },
 {


### PR DESCRIPTION
## Summary
- Searching for "Cyril" surfaced that the May 11 joint commemoration ("Holy Equals-to-the-Apostles Methodius and Cyril, first teachers of the Slavs") was linked to a synthetic Saint row whose name was the entire joint title, disconnected from the two individuals' own solo Saint rows (St Methodius, Enlightener of the Slavs; St Cyril, Teacher of the Slavs) -- the same joint-identity pattern the saint-model-refactor project (#150) was built to fix.
- Repointed the existing `DayCommemorationSaint` link to the real Methodius row, added a second link for the real Cyril row (order 1/2, matching the title's own ordering), and deleted the now-orphaned synthetic Saint row.
- Verified via the saint search/detail pages: both saints now correctly show the May 11 joint commemoration alongside their solo ones.

Noted in passing but **not** included here: the same pattern exists on the neighboring "Holy Equals-to-the-Apostles Emperor Constantine and Helen, his mother" commemoration -- flagging for a possible follow-up, out of scope for this PR.

## Test plan
- [x] `docker compose run --rm tests` -- 152 tests pass
- [x] Verified in-browser: saint search for "Cyril" and "Methodius" both show the joint May 11 commemoration linked correctly, with the shared story rendering under the right saint page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3