### PR TITLE
Add a Tip Jar link and consolidate the site nav into submenus

### DIFF
--- a/orthocal/static/main.css
+++ b/orthocal/static/main.css
@@ -87,7 +87,7 @@ h1, h2, h3, h4 {
     gap: 1.4em;
     justify-content: flex-end;
 }
-.topbar-inner > nav li {
+.topbar-inner > nav > ul > li {
     display: inline;
     text-transform: lowercase;
 }
@@ -100,6 +100,65 @@ h1, h2, h3, h4 {
 .topbar-inner > nav a:hover {
     color: black;
     text-shadow: 2px 2px 3px #bbb;
+}
+
+/* Submenu (e.g. "Developers") -- a native <details>/<summary> disclosure
+   rather than a CSS :hover flyout, so it works identically (click to open,
+   no separate touch/mouse logic) whether it's in the inline desktop row or
+   stacked in the mobile hamburger dropdown below. */
+.topbar-inner > nav details {
+    display: inline;
+    position: relative;
+}
+.topbar-inner > nav summary {
+    display: inline;
+    cursor: pointer;
+    color: #777;
+    list-style: none;
+    text-transform: lowercase;
+    transition-property: color, text-shadow;
+    transition-duration: 0.3s;
+}
+.topbar-inner > nav summary::-webkit-details-marker {
+    display: none;
+}
+.topbar-inner > nav summary::after {
+    content: " \25be";
+    font-size: 0.7em;
+    vertical-align: middle;
+}
+.topbar-inner > nav details[open] summary::after {
+    content: " \25b4";
+}
+.topbar-inner > nav summary:hover {
+    color: black;
+    text-shadow: 2px 2px 3px #bbb;
+}
+.topbar-inner > nav details ul {
+    list-style: none;
+    margin: 0.6em 0 0 0;
+    padding: 0;
+    position: absolute;
+    top: 100%;
+    right: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-end;
+    gap: 0;
+    box-sizing: border-box;
+    width: 10em;
+    background-color: #fdfaf5;
+    border: 1px solid #bbb3a0;
+    box-shadow: -2px 3px 6px rgba(0, 0, 0, 0.15);
+    z-index: 20;
+}
+.topbar-inner > nav details ul li {
+    display: block;
+    text-transform: lowercase;
+    box-sizing: border-box;
+    width: 100%;
+    padding: 0.4em 1em;
 }
 
 /* Hamburger menu -- hidden until the site nav would wrap */
@@ -124,7 +183,7 @@ h1, h2, h3, h4 {
 .nav-toggle:hover span {
     background-color: #333;
 }
-@media (max-width: 1350px) {
+@media (max-width: 1050px) {
     .topbar-inner {
         align-items: center;
         position: relative;
@@ -139,7 +198,7 @@ h1, h2, h3, h4 {
         text-align: right;
         margin-left: -1.5em;
     }
-    .topbar-inner > nav ul {
+    .topbar-inner > nav > ul {
         display: none;
         position: absolute;
         top: 100%;
@@ -154,13 +213,35 @@ h1, h2, h3, h4 {
         box-shadow: -2px 3px 6px rgba(0, 0, 0, 0.15);
         z-index: 20;
     }
-    .topbar-inner > nav.nav-open ul {
+    .topbar-inner > nav.nav-open > ul {
         display: flex;
     }
-    .topbar-inner > nav li {
+    .topbar-inner > nav > ul > li {
         box-sizing: border-box;
         width: 100%;
         padding: 0.4em 1em;
+    }
+    /* The "Developers" submenu stacks in normal flow here instead of
+       floating as its own boxed dropdown -- it's already inside the
+       hamburger panel, so it just needs to read as an indented,
+       collapsible group within that list rather than a second popup. */
+    .topbar-inner > nav details {
+        display: block;
+        width: 100%;
+    }
+    .topbar-inner > nav summary {
+        display: block;
+    }
+    .topbar-inner > nav details ul {
+        position: static;
+        width: 100%;
+        margin: 0;
+        background: none;
+        border: none;
+        box-shadow: none;
+    }
+    .topbar-inner > nav details ul li {
+        padding: 0.4em 1em 0.4em 2em;
     }
 }
 /* Last resort: viewport too narrow even for the smallest scaled title font
@@ -195,6 +276,7 @@ nav.page-nav {
 .day-nav {
     display: flex;
     flex-wrap: nowrap;
+    text-transform: lowercase;
 }
 nav.page-nav a:link, nav.page-nav a:visited {
     text-decoration: none;

--- a/orthocal/templates/base.html
+++ b/orthocal/templates/base.html
@@ -62,11 +62,26 @@
 						<li><a href="{% url "index" %}">Readings</a></li>
 						<li><a href="{% url "calendar-default" %}">Calendar</a></li>
 						<li><a href="{% url "saint-search" %}">Saints</a></li>
-						<li><a href="{% url "alexa" %}">Alexa</a></li>
-						<li><a href="{% url "api" %}">API</a></li>
-						<li><a href="{% url "ai-assistant" %}">AI</a></li>
-						<li><a href="{% url "feeds" %}">Feeds</a></li>
-						<li><a href="{% url "about" %}">About</a></li>
+						<li>
+							<details name="nav-submenu">
+								<summary>Integrations</summary>
+								<ul>
+									<li><a href="{% url "alexa" %}">Alexa</a></li>
+									<li><a href="{% url "api" %}">API</a></li>
+									<li><a href="{% url "ai-assistant" %}">AI</a></li>
+									<li><a href="{% url "feeds" %}">Feeds</a></li>
+								</ul>
+							</details>
+						</li>
+						<li>
+							<details name="nav-submenu">
+								<summary>More</summary>
+								<ul>
+									<li><a href="{% url "about" %}">About</a></li>
+									<li><a href="https://paypal.me/BGlass42" target="_blank" rel="noopener">Tip Jar</a></li>
+								</ul>
+							</details>
+						</li>
 					</ul>
 				</nav>
 			</div>


### PR DESCRIPTION
## Summary
- Top-level nav had grown to 9 items. Grouped Alexa/API/AI/Feeds under an "Integrations" submenu, and About + the new Tip Jar link under "More" -- down to 5 top-level items.
- Submenus use native `<details>`/`<summary>` instead of a CSS `:hover` flyout, so the same markup/behavior works identically whether the nav is in its full inline row or stacked in the mobile hamburger dropdown. Both share `name="nav-submenu"` so opening one natively closes the other (HTML accordion grouping, no JS).
- Added a Tip Jar link (`https://paypal.me/BGlass42`, opens in a new tab) inside "More".
- Day-nav ("Previous Day"/"Today"/"Next Day") forced to lowercase via CSS, matching the rest of the nav.
- Hamburger breakpoint dropped from 1350px to 1050px to match the now-shorter nav's actual space needs, re-measured the same way as the original breakpoint (full nav at max title size vs. available width) to keep a comparable safety margin.

## Test plan
- [x] `docker compose run --rm tests` -- 152 tests pass
- [x] Verified in-browser: mobile hamburger dropdown (nested submenu expand/collapse, real narrow viewport), and the real inline desktop nav at 1243px (below the old 1350px breakpoint, above the new 1050px one) confirming the breakpoint change works and the flyout dropdown positions correctly
- [x] Verified opening one submenu (Integrations) auto-closes the other (More) and vice versa

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3