### PR TITLE
Serve static assets from Firebase Hosting's CDN instead of proxying through Cloud Run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ ve
 .coverage
 .firebase
 static
+public/media
 default-cache

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,24 @@ deploy:
 test:
 	docker run -it -e PORT=8000 -p8000:8000 orthocal ./manage.py test
 
-firebase:
+firebase: collectstatic
 	firebase use --add orthocal-1d1b9
 	firebase deploy --only hosting
+
+# Regenerates static/ (Django's STATIC_ROOT) via the same collectstatic
+# step the Dockerfile runs at image-build time, then mirrors it into
+# public/media -- matching STATIC_URL='media/' -- so Firebase Hosting
+# serves these files directly from its own CDN instead of proxying every
+# request through Cloud Run. Firebase's rewrite in firebase.json only
+# applies as a fallback for paths that don't match a real file under
+# public/, so no rewrite changes are needed for this to take effect.
+collectstatic:
+	docker compose run --rm local ./manage.py collectstatic --noinput
+	rm -rf public/media
+	mkdir -p public/media
+	cp -r static/* public/media/
+	# servestatic pre-compresses sidecar files (.br/.gz/.zstd) for its own
+	# on-disk serving scheme; Firebase Hosting compresses on the fly at its
+	# own CDN edge and never looks for these, so they'd just be dead weight
+	# in the deploy.
+	find public/media \( -name '*.br' -o -name '*.gz' -o -name '*.zstd' \) -print0 | xargs -0 rm -f


### PR DESCRIPTION
## Summary
- `make firebase` now runs `collectstatic` first and mirrors the output into `public/media` (matching `STATIC_URL='media/'`), so Firebase Hosting serves these files directly from its own CDN on the next deploy instead of proxying every static-asset request through Cloud Run.
- No `firebase.json` changes needed -- Firebase Hosting only falls back to the catch-all Cloud Run rewrite when no literal file matches under `public/`, so a matching file there is served directly. Confirmed this empirically via the Firebase Hosting emulator (see test plan).
- `public/media` is gitignored (build output, regenerated by the Makefile target) and servestatic's own compressed sidecar files (`.br`/`.gz`/`.zstd`) are stripped from the copy, since Firebase compresses on the fly at its CDN edge and never looks for them.
- `servestatic` itself stays in the app -- it's still needed for local dev (no Firebase Hosting in front of `docker compose`) and the `orthocal-dev` Cloud Run service (not covered by `firebase.json`'s rewrite, which is hardcoded to the `orthocal` service), plus it's a reasonable fallback if a `make firebase` deploy is ever forgotten.

## Test plan
- [x] `make collectstatic` runs cleanly and produces 79 files in `public/media`, with zero leftover `.br`/`.gz`/`.zstd` sidecar files.
- [x] Firebase Hosting emulator (`firebase emulators:start --only hosting`) serves `main.css` and `htmx.min.js` from `public/media` with status 200 and content byte-identical to the source files, with no `firebase.json` changes.
- [ ] Run `make firebase` for a real deploy (manual, left to Brian).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3