### PR TITLE
Move the main-branch Cloud Build trigger's steps into a tracked cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,79 @@
+steps:
+  - id: Build
+    name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - --no-cache
+      - -t
+      - $_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA
+      - .
+      - -f
+      - Dockerfile
+  - id: Push
+    name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - $_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA
+  - id: Deploy
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    entrypoint: gcloud
+    args:
+      - run
+      - services
+      - update
+      - $_SERVICE_NAME
+      - --platform=managed
+      - --image=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA
+      - --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS
+      - --region=$_DEPLOY_REGION
+      - --quiet
+  - id: UpdateJob
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    entrypoint: gcloud
+    args:
+      - run
+      - jobs
+      - update
+      - $_JOB_NAME
+      - --image=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA
+      - --region=$_DEPLOY_REGION
+      - --quiet
+  # Extracts the collectstatic output that the Dockerfile already baked into
+  # the just-built image, so Firebase Hosting can serve it directly from its
+  # own CDN (see firebase.json's rewrite, which only falls back to Cloud Run
+  # for paths that don't match a real file under public/) instead of every
+  # static-asset request proxying through Cloud Run.
+  - id: ExtractStatic
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -e
+        docker create --name static-extract $_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA
+        rm -rf public/media
+        mkdir -p public/media
+        docker cp static-extract:/orthocal/static/. public/media/
+        docker rm static-extract
+        # servestatic pre-compresses sidecar files (.br/.gz/.zstd) for its own
+        # on-disk serving scheme; Firebase Hosting compresses on the fly at
+        # its own CDN edge and never looks for these, so they'd just be dead
+        # weight in the deploy.
+        find public/media \( -name '*.br' -o -name '*.gz' -o -name '*.zstd' \) -delete
+  # Auth is implicit via the Cloud Build service account's
+  # roles/firebasehosting.admin IAM binding (Application Default
+  # Credentials, auto-detected from Cloud Build's metadata server) -- no
+  # token or key needed here.
+  - id: FirebaseDeploy
+    name: node:20
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -e
+        npm install -g firebase-tools@15
+        firebase deploy --only hosting --project $PROJECT_ID --non-interactive
+images:
+  - $_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA
+options:
+  substitutionOption: ALLOW_LOOSE


### PR DESCRIPTION
## Summary
- Adds `cloudbuild.yaml`, mirroring the `orthocal` Cloud Run deploy trigger's current live build steps exactly (Build, Push, Deploy, UpdateJob, plus the ExtractStatic/FirebaseDeploy steps added for Firebase Hosting's static-asset offload -- see #187).
- Not wired up yet -- the trigger keeps using its inline config until this merges. Cloud Build reads a `filename`-referenced config from the branch that triggered the build, so pointing the trigger at this file before it exists on `main` would break the next deploy.
- Follow-up after merge: update the trigger to use `filename: cloudbuild.yaml` instead of its inline `build` block. Substitution values (`_DEPLOY_REGION`, `_SERVICE_NAME`, `_JOB_NAME`, etc.) stay on the trigger itself, not duplicated in this file, since a filename-based config still receives them from the trigger at build time.

## Why
This repo is public, and nothing in this build pipeline is secret -- every step authenticates implicitly via the Cloud Build service account's IAM role bindings (most recently `roles/firebasehosting.admin`), never an embedded token or key. Keeping it in git means it's diffable, reviewable, and has real history -- the inline-only setup is exactly how a duplicate, years-stale trigger (`76b104f9`, deploying the same Cloud Run service on every push to main) went unnoticed until this session.

## Test plan
- [x] Content diffed 1:1 against the currently-live trigger's exported config (`gcloud beta builds triggers export`) to confirm no behavior change.
- [ ] After merge: update the trigger's `filename` field and confirm the next push to `main` builds successfully from this file (manual, left to Brian).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3