### PR TITLE
Close nav dropdowns on an outside click

### DIFF
--- a/orthocal/templates/base.html
+++ b/orthocal/templates/base.html
@@ -111,6 +111,18 @@
 					toggle.setAttribute('aria-expanded', isOpen);
 				});
 			});
+
+			// Native <details> only closes on a second click on its own
+			// <summary> (or when a sibling in the same name= group opens) --
+			// it doesn't close on a click elsewhere on the page, which reads
+			// as broken for a nav dropdown.
+			document.addEventListener('click', function (event) {
+				document.querySelectorAll('.topbar-inner > nav details[open]').forEach(function (details) {
+					if (!details.contains(event.target)) {
+						details.removeAttribute('open');
+					}
+				});
+			});
 		</script>
 
         {% block scripts %}{% endblock %}


### PR DESCRIPTION
## Summary
- The "Integrations"/"More" nav dropdowns (native `<details>/<summary>`) only closed on a second click on their own summary. Clicking anywhere else on the page left them open.
- Adds a delegated click listener in `base.html` that closes any open `.topbar-inner > nav details` whose subtree doesn't contain the click target -- clicks on the dropdown's own links are left alone so navigation still works normally.

## Test plan
- [x] Verified in-browser: summary click opens the dropdown, a click elsewhere closes it, a click on a link inside the open dropdown does not force-close it before navigating.
- [x] `docker compose run --rm tests` -- all 152 tests pass (JS-only change, no test coverage expected to be affected).

Also serves as the first real end-to-end test of the new `cloudbuild.yaml`-based deploy pipeline (#189) -- merging this should trigger a build sourced entirely from the tracked config file for the first time.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3