### PR TITLE
Optimize font loading: drop dead font bundle, replace Optima with Ysabeau

### DIFF
--- a/orthocal/settings.py
+++ b/orthocal/settings.py
@@ -239,7 +239,6 @@ USE_TZ = True
 
 STATIC_URL = 'media/'
 STATIC_ROOT = BASE_DIR / 'static'
-STATICFILES_DIRS = [BASE_DIR / 'fonts']
 
 STORAGES = {
     "staticfiles": {

--- a/orthocal/static/main.css
+++ b/orthocal/static/main.css
@@ -76,7 +76,8 @@ h1, h2, h3, h4 {
     margin: 0;
     padding: 0;
     text-align: right;
-    font-family: Optima, sans-serif;
+    font-family: 'Ysabeau', sans-serif;
+    font-size: 1.1em;
 }
 .topbar-inner > nav ul {
     list-style: none;
@@ -116,6 +117,7 @@ h1, h2, h3, h4 {
     color: #777;
     list-style: none;
     text-transform: lowercase;
+    white-space: nowrap;
     transition-property: color, text-shadow;
     transition-duration: 0.3s;
 }
@@ -183,7 +185,7 @@ h1, h2, h3, h4 {
 .nav-toggle:hover span {
     background-color: #333;
 }
-@media (max-width: 1050px) {
+@media (max-width: 1200px) {
     .topbar-inner {
         align-items: center;
         position: relative;
@@ -263,8 +265,8 @@ nav.page-nav {
     width: 75%;
     margin: 0 auto;
     padding: 0.4em 0 0.15em 0;
-    font-size: clamp(0.6em, calc(3cqw), 1em);
-    font-family: Optima, sans-serif;
+    font-size: clamp(0.65em, calc(3.2cqw), 1.1em);
+    font-family: 'Ysabeau', sans-serif;
 }
 .page-nav-row {
     display: flex;
@@ -419,10 +421,10 @@ section.readings h2 {
 	display: inline-flex;
 	align-items: center;
 	gap: 0.4em;
-	font-family: Optima, sans-serif;
+	font-family: 'Ysabeau', sans-serif;
 }
 .translation-picker select {
-	font-family: Optima, sans-serif;
+	font-family: 'Ysabeau', sans-serif;
 	font-size: 1.1em;
 	color: #333;
 	background-color: #fff;

--- a/orthocal/templates/base.html
+++ b/orthocal/templates/base.html
@@ -21,8 +21,8 @@
 		<!-- Load Fonts -->
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital@0;1&display=fallback" rel="preload" as="style">
-        <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital@0;1&display=fallback" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital@0;1&family=Ysabeau&display=fallback" rel="preload" as="style">
+        <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital@0;1&family=Ysabeau&display=fallback" rel="stylesheet">
 
 		<!-- Google tag (gtag.js) -->
 		<link rel="preconnect" href="https://www.googletagmanager.com">


### PR DESCRIPTION
## Summary
- Drops \`STATICFILES_DIRS = [BASE_DIR / 'fonts']\` from \`settings.py\` and deletes the local \`fonts/\` directory (a saved copy of Google Fonts' own CSS response for EB Garamond plus its 14 \`.woff2\` files, never committed to git, never referenced by any \`@font-face\`) -- dead weight bundled into every static-asset deploy via \`collectstatic\`.
- Replaces \`Optima\` (used for nav/menu text) with \`Ysabeau\`. Optima was a pure system-font fallback with nothing actually loaded for it (it's proprietary, so there was never a web font backing it) -- present on macOS/iOS, silently falling back to \`sans-serif\` everywhere else. Ysabeau is on Google Fonts and folds into the same combined CSS2 request already used for EB Garamond, so it's still just one Google Fonts request total.
- Along the way: bumped nav/day-nav font sizes slightly to suit Ysabeau's proportions, fixed the "Integrations"/"More" dropdown arrow wrapping onto its own line under tight width (\`summary\` lacked \`white-space: nowrap\`), and recalibrated the hamburger breakpoint (1050px -> 1200px) via the same live in-browser measurement approach used for the original calibration.

## Test plan
- [x] \`docker compose run --rm tests\` -- all 152 tests pass.
- [x] Full \`--clear\` collectstatic rebuild confirms no \`fonts/\` output remains.
- [x] Verified in-browser: Ysabeau renders correctly across nav/day-nav/translation picker, dropdown arrows no longer wrap, hamburger breakpoint switches correctly at the new width.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3