### PR TITLE
URL-encode the url param in the oEmbed discovery link

### DIFF
--- a/calendarium/templates/calendar.html
+++ b/calendarium/templates/calendar.html
@@ -10,7 +10,7 @@
 		<meta name="description" content="An Orthodox calendar including information about feasts, fasts, commemorations, and readings for the month of {{ this_month|date:"F Y" }}.">
 	{% endif %}
 
-	<link rel="alternate" type="application/json+oembed" href="{% fullurl "api:get_calendar_embed" %}?url={{ request.build_absolute_uri }}">
+	<link rel="alternate" type="application/json+oembed" href="{% fullurl "api:get_calendar_embed" %}?url={{ request.build_absolute_uri|urlencode:"" }}">
 	<link rel="canonical" href="{% fullurl "calendar" tradition=tradition cal=cal year=this_month.year month=this_month.month %}">
 
 	{% if noindex %}


### PR DESCRIPTION
## Summary
The oEmbed spec (https://oembed.com/) says the `url` request parameter "SHOULD be URL-escaped." The calendar page's discovery `<link>` was concatenating `request.build_absolute_uri` raw into the query string instead:

    <link ... href=".../oembed/calendar/?url=https://orthocal.info/calendar/...">

Django's own lenient GET-parameter parsing tolerates this for calendar URLs (no `&`/`=` in the embedded path to collide with), so it still resolves correctly end-to-end when tested directly -- but it's a real spec violation, and a stricter oEmbed consumer/validator has no principled way to tell where the query string's `url` value ends given the embedded URL's own `://` and `/` characters. This likely explains the occasional mangled `https:/orthocal.info/...` (single slash) requests visible in production logs -- a client normalizing what it can't unambiguously parse.

Fixed with `|urlencode:""` (empty safe-chars, so `:` and `/` get escaped too, not just the filter's default-safe `/`).

## Test plan
- [x] `docker compose run --rm tests` -- all 152 tests pass.
- [x] Verified in-browser: discovery link now renders fully percent-encoded (`url=http%3A%2F%2F...`) and round-trips back to the exact original URL when parsed.
- [x] Confirmed the endpoint still resolves correctly end-to-end with the properly-encoded value (200, correct oEmbed JSON).
- [x] Checked other templates for the same "full URL nested in a query string" pattern -- this was the only occurrence.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3