### PR TITLE
Drop google-cloud-logging in favor of New Relic log forwarding

### DIFF
--- a/orthocal/middleware.py
+++ b/orthocal/middleware.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.utils import timezone
 from django.utils.cache import get_max_age, patch_cache_control, patch_vary_headers
 from django.utils.decorators import sync_and_async_middleware
-from google.cloud.logging_v2.handlers.middleware import RequestMiddleware
 from newrelic.api.transaction import current_transaction
 
 logger = logging.getLogger(__name__)
@@ -56,18 +55,6 @@ def log_language(get_response):
         def middleware(request):
             log_language(request)
             return get_response(request)
-
-    return middleware
-
-@sync_and_async_middleware
-def google_logging_middleware(get_response):
-    if iscoroutinefunction(get_response):
-        async def middleware(request):
-            response = await get_response(request)
-            google_middleware = RequestMiddleware(lambda request: response)
-            return google_middleware(request)
-    else:
-        middleware = RequestMiddleware(get_response)
 
     return middleware
 

--- a/orthocal/settings.py
+++ b/orthocal/settings.py
@@ -56,8 +56,6 @@ ORTHOCAL_WEBSUB_URL = 'https://pubsubhubbub.appspot.com'
 ORTHOCAL_API_RATELIMIT = os.environ.get('API_RATELIMIT', '5/s')
 ORTHOCAL_REVISION = os.environ.get('K_REVISION', str(uuid.uuid4()))
 
-IS_GCLOUD = 'K_REVISION' in os.environ
-
 if TESTING:
     RATELIMIT_ENABLE = False
 
@@ -153,13 +151,11 @@ CACHES = {
 
 CACHE_MIDDLEWARE_SECONDS = ORTHOCAL_MAX_AGE
 
-HANDLER = 'gcloud' if IS_GCLOUD else 'console'
-
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
     'root': {
-        'handlers': [HANDLER],
+        'handlers': ['console'],
         'level': 'DEBUG',
     },
     'formatters': {
@@ -174,10 +170,6 @@ LOGGING = {
             'formatter': 'simple',
             'level': 'DEBUG',
         },
-        "gcloud": {
-            "class": "google.cloud.logging.handlers.StructuredLogHandler",
-            'level': 'DEBUG',
-        },
     },
     'loggers': {
         'django.request': {
@@ -188,11 +180,11 @@ LOGGING = {
         },
         'uvicorn': {
             'level': 'DEBUG',
-            'handlers': [HANDLER],
+            'handlers': ['console'],
         },
         'uvicorn.error': {
             'level': 'DEBUG',
-            'handlers': [HANDLER],
+            'handlers': ['console'],
         },
         'alexa': {
             'level': 'DEBUG',

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ django-cors-headers==4.9.0
 django-fullurl==1.4
 django-ninja==1.6.3
 django==6.1
-google-cloud-logging==3.16.2
 icalendar==7.2.2
 jdcal==1.4.1
 mcp==2.0.0


### PR DESCRIPTION
## Summary
Investigated production startup cost via \`python -X importtime\` against the real app entrypoint. \`google-cloud-logging\`'s \`StructuredLogHandler\` alone accounted for ~105ms of ~726ms total import time -- despite the handler class itself having zero \`grpc\`/\`Client\` dependency in its own source, the cost comes from the package's \`__init__.py\` eagerly importing the whole grpc-based API client machinery regardless of which piece is used.

Rather than defer that cost (it's genuinely needed in production while using the package, since \`HANDLER='gcloud'\` there), dropping the dependency entirely: New Relic's Python agent already runs in this process via the \`newrelic-admin\` entrypoint wrapper regardless of anything in \`asgi.py\`, and has built-in log forwarding (\`application_logging.enabled\` / \`application_logging.forwarding.enabled\` in \`newrelic.ini\`) that costs zero additional imports, since the agent is already loaded either way. Primary New Relic usage here is APM transactions; consolidating logs there too avoids paying for a second logging pipeline's import cost on every cold start.

## Changes
- \`orthocal/settings.py\`: removed the \`'gcloud'\` handler and \`IS_GCLOUD\`/\`HANDLER\` indirection from \`LOGGING\` -- always uses \`'console'\` now. Cloud Run's own platform-level request logging/metrics come from its infrastructure layer, independent of the app's logging library choice, so this doesn't affect that.
- \`orthocal/middleware.py\`: removed \`google_logging_middleware\` -- confirmed via grep it was never wired into \`MIDDLEWARE\` or referenced anywhere, dead code that would have broken on import once the package left \`requirements.txt\`.
- \`requirements.txt\`: removed \`google-cloud-logging\`.

Production \`newrelic.ini\` (in Secret Manager, not this repo) needs \`application_logging.enabled=true\` / \`application_logging.forwarding.enabled=true\` added under \`[newrelic:production]\` for log forwarding to actually activate -- that's a manual step outside this PR (left to Brian).

## Test plan
- [x] \`docker compose build tests && docker compose run --rm tests\` -- 162/162 pass.
- [x] Confirmed no remaining references to \`google.cloud.logging\`/\`google_cloud_logging\` anywhere in the codebase.
- [x] Verified via \`python -X importtime\`: total cumulative import time for \`from orthocal.asgi import application\` dropped from 726340us to 621514us -- a ~105ms reduction, matching the measured cost exactly, with no offsetting new cost.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3