### PR TITLE
Fix scroll jump on toggle/select changes in Microsoft Edge (CSS scroll-anchoring fix)

### DIFF
--- a/calendarium/templates/readings.html
+++ b/calendarium/templates/readings.html
@@ -100,7 +100,7 @@
 		{% if day.language == "en" %}
 		<p class="translation-picker">
 			<label for="translation-select">Translation:
-				<select id="translation-select" hx-get="" hx-on::config-request="event.detail.path = this.value" hx-select="#orthocal" hx-target="#orthocal" hx-swap="outerHTML" hx-push-url="true">
+				<select id="translation-select" hx-get="" hx-on::config-request="event.detail.path = this.value" hx-select="#scripture-readings" hx-target="#scripture-readings" hx-swap="outerHTML" hx-push-url="true">
 					{% for value, label in translation_choices %}
 					<option value="{% url "readings" tradition=tradition cal=cal translation=value year=date.year month=date.month day=date.day %}" {% if translation == value %}selected{% endif %}>{{ label }}</option>
 					{% endfor %}
@@ -110,6 +110,7 @@
 		</p>
 		{% endif %}
 
+		<div id="scripture-readings">
 		{% for reading in day.readings %}
 		<article class="passage" id="reading-{{ reading.id }}">
 			<h2>
@@ -125,6 +126,7 @@
 			</p>
 		</article>
 		{% endfor %}
+		</div>
 	</section>
 
 	<section class="readings">

--- a/orthocal/static/main.css
+++ b/orthocal/static/main.css
@@ -267,6 +267,13 @@ nav.page-nav {
     padding: 0.4em 0 0.15em 0;
     font-size: clamp(0.65em, calc(3.2cqw), 1.1em);
     font-family: 'Ysabeau', sans-serif;
+    /* This whole element is destroyed and rebuilt via an htmx OOB swap on
+       every readings/calendar navigation. When it's near the top of the
+       viewport, Chromium's CSS Scroll Anchoring can pick an anchor node
+       from inside it; destroying that node mid-swap makes the browser
+       re-anchor elsewhere, producing a visible scroll jump (seen in Edge).
+       Opting this subtree out of anchor selection avoids that entirely. */
+    overflow-anchor: none;
 }
 .page-nav-row {
     display: flex;

--- a/orthocal/templates/base.html
+++ b/orthocal/templates/base.html
@@ -123,52 +123,6 @@
 					}
 				});
 			});
-
-			// The day-nav links and the tradition/calendar/translation
-			// controls all swap #orthocal in place via htmx, but they live
-			// inside #page-nav, which is refreshed on every such request via
-			// an out-of-band swap -- so the very control the user just used
-			// gets removed from the DOM and replaced by a new node. Some
-			// browsers move the viewport when the focused element disappears
-			// like that (observed jumping/scrolling in Edge). None of these
-			// are real navigations, so pin the scroll position across them.
-			//
-			// (We tried hx-preserve on the toggle radios instead, so the
-			// live node -- and its focus -- would never be removed in the
-			// first place. That's the "correct" fix, but htmx's hx-preserve
-			// implementation uses the Element.moveBefore API via a shared
-			// staging element, and with more than one hx-preserve sibling
-			// swapping at once (our 2 tradition + 2 calendar radios, all in
-			// one #page-nav OOB swap) it deterministically strips the id/
-			// hx-preserve attributes off the moved nodes every other swap --
-			// reproduced locally on both our pinned 2.0.4 and current 2.0.10,
-			// so not a version-specific bug we can fix by upgrading. Not
-			// safe to ship, so back to pinning scroll position directly.)
-			//
-			// A single correction on htmx:afterSettle is visibly late in
-			// Edge: the erroneous scroll already painted, so the fix reads
-			// as a jump-then-snap-back "blink" rather than nothing happening.
-			// Instead, re-assert the saved position on every scroll event
-			// that occurs during the request, so any stray scroll gets
-			// cancelled out within the same event, before the user
-			// perceives it having settled anywhere else.
-			var htmxSavedScrollY = null;
-			function htmxRelockScroll() {
-				if (htmxSavedScrollY !== null) {
-					window.scrollTo(0, htmxSavedScrollY);
-				}
-			}
-			document.addEventListener('htmx:beforeRequest', function (event) {
-				var elt = event.detail.elt;
-				if (elt && elt.getAttribute && elt.getAttribute('hx-target') === '#orthocal') {
-					htmxSavedScrollY = window.scrollY;
-					window.addEventListener('scroll', htmxRelockScroll);
-				}
-			});
-			document.addEventListener('htmx:afterSettle', function () {
-				window.removeEventListener('scroll', htmxRelockScroll);
-				htmxSavedScrollY = null;
-			});
 		</script>
 
         {% block scripts %}{% endblock %}

--- a/orthocal/templates/base.html
+++ b/orthocal/templates/base.html
@@ -132,17 +132,42 @@
 			// browsers move the viewport when the focused element disappears
 			// like that (observed jumping/scrolling in Edge). None of these
 			// are real navigations, so pin the scroll position across them.
+			//
+			// (We tried hx-preserve on the toggle radios instead, so the
+			// live node -- and its focus -- would never be removed in the
+			// first place. That's the "correct" fix, but htmx's hx-preserve
+			// implementation uses the Element.moveBefore API via a shared
+			// staging element, and with more than one hx-preserve sibling
+			// swapping at once (our 2 tradition + 2 calendar radios, all in
+			// one #page-nav OOB swap) it deterministically strips the id/
+			// hx-preserve attributes off the moved nodes every other swap --
+			// reproduced locally on both our pinned 2.0.4 and current 2.0.10,
+			// so not a version-specific bug we can fix by upgrading. Not
+			// safe to ship, so back to pinning scroll position directly.)
+			//
+			// A single correction on htmx:afterSettle is visibly late in
+			// Edge: the erroneous scroll already painted, so the fix reads
+			// as a jump-then-snap-back "blink" rather than nothing happening.
+			// Instead, re-assert the saved position on every scroll event
+			// that occurs during the request, so any stray scroll gets
+			// cancelled out within the same event, before the user
+			// perceives it having settled anywhere else.
 			var htmxSavedScrollY = null;
+			function htmxRelockScroll() {
+				if (htmxSavedScrollY !== null) {
+					window.scrollTo(0, htmxSavedScrollY);
+				}
+			}
 			document.addEventListener('htmx:beforeRequest', function (event) {
 				var elt = event.detail.elt;
 				if (elt && elt.getAttribute && elt.getAttribute('hx-target') === '#orthocal') {
 					htmxSavedScrollY = window.scrollY;
+					window.addEventListener('scroll', htmxRelockScroll);
 				}
 			});
 			document.addEventListener('htmx:afterSettle', function () {
-				if (htmxSavedScrollY !== null) {
-					window.scrollTo(0, htmxSavedScrollY);
-				}
+				window.removeEventListener('scroll', htmxRelockScroll);
+				htmxSavedScrollY = null;
 			});
 		</script>
 

--- a/orthocal/templates/base.html
+++ b/orthocal/templates/base.html
@@ -123,6 +123,27 @@
 					}
 				});
 			});
+
+			// The day-nav links and the tradition/calendar/translation
+			// controls all swap #orthocal in place via htmx, but they live
+			// inside #page-nav, which is refreshed on every such request via
+			// an out-of-band swap -- so the very control the user just used
+			// gets removed from the DOM and replaced by a new node. Some
+			// browsers move the viewport when the focused element disappears
+			// like that (observed jumping/scrolling in Edge). None of these
+			// are real navigations, so pin the scroll position across them.
+			var htmxSavedScrollY = null;
+			document.addEventListener('htmx:beforeRequest', function (event) {
+				var elt = event.detail.elt;
+				if (elt && elt.getAttribute && elt.getAttribute('hx-target') === '#orthocal') {
+					htmxSavedScrollY = window.scrollY;
+				}
+			});
+			document.addEventListener('htmx:afterSettle', function () {
+				if (htmxSavedScrollY !== null) {
+					window.scrollTo(0, htmxSavedScrollY);
+				}
+			});
 		</script>
 
         {% block scripts %}{% endblock %}


### PR DESCRIPTION
## Summary
- Reported in Edge: changing the tradition/calendar toggle radios, day-nav links, or the translation `<select>` on the readings page caused the window to jump/scroll unexpectedly. Not reproducible in Chrome.
- Root cause: **CSS Scroll Anchoring**. Chromium picks an anchor element near the top of the viewport and adjusts scroll to keep it visually stable whenever content above it changes height. `#page-nav` is destroyed and rebuilt wholesale on every readings/calendar htmx request (an out-of-band swap) — whenever the browser's chosen anchor happened to live inside it, destroying it mid-swap forced a re-anchor and a visible jump. Explains why it only happened when the clicked control was near the top of the viewport: scrolled further down, the anchor sits in the untouched main content instead.
- Fix: `overflow-anchor: none` on `nav.page-nav`, opting that subtree out of anchor selection. One line of CSS, no JS, no backend change.
- Also narrowed the translation `<select>`'s swap target from `#orthocal` to a new `#scripture-readings` wrapper around just the reading articles, since a translation change never affects anything else. That means the select's own DOM node is never touched by any swap, for any interaction — genuinely optimal, not just visually masked.
- An earlier commit on this branch used a reactive `htmx:beforeRequest`/scroll-relock JS workaround before the actual cause was identified; removed once the CSS fix landed (see PR comments for the full investigation, including a since-abandoned attempt at `hx-preserve`, which turned out to have a real upstream htmx bug with multiple preserved siblings in one OOB swap).

**Known remaining gap, out of scope by request**: day-nav links and toggle radios still fully destroy/rebuild `#page-nav`'s DOM on every click (the OOB swap is sized for the whole element, not just what changed). `overflow-anchor` stops that from being visible, but those controls still silently lose keyboard focus on every interaction. Fixing that precisely would require the server to track old-vs-new tradition/cal/translation/day to know which OOB blocks it can skip rendering — a backend change, deliberately not pursued here.

## Test plan
- [x] `docker compose build tests && docker compose run --rm tests` — 162/162 passing
- [x] Confirmed in real Microsoft Edge: toggle radios, day-nav links, and the translation select no longer jump/scroll
- [x] Confirmed translation select swap correctness (real content swap verified, not just scroll position) after ruling out a local dev-server ETag caching false alarm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3