### PR TITLE
Fix missing hyphenation in Safari

### DIFF
--- a/orthocal/static/main.css
+++ b/orthocal/static/main.css
@@ -371,9 +371,11 @@ main#orthocal > header h1 span {
 	font-variant: small-caps;
 }
 
+/* No text-wrap: pretty here -- Safari supports the property but its
+   implementation drops hyphens: auto for any rule that also declares it,
+   so we skip it everywhere rather than special-case a browser in CSS. */
 #content {
     text-align: justify;
-    text-wrap: pretty;
     -webkit-hyphens: auto;
     -moz-hyphens: auto;
     -ms-hyphens: auto;
@@ -458,7 +460,6 @@ section.readings h2 {
     widows: 3;
     orphans: 3;
     text-align: justify;
-    text-wrap: pretty;
     -webkit-hyphens: auto;
     -moz-hyphens: auto;
     -ms-hyphens: auto;


### PR DESCRIPTION
## Summary
- Scripture-reading and static-page body text wasn't hyphenating in Safari (desktop, v26.6.2), even though the correct `-webkit-hyphens: auto`/`hyphens: auto` and a matching `lang` attribute were already in place.
- Root cause, confirmed by toggling declarations off live in Safari's Web Inspector: `text-wrap: pretty` is supported by Safari, but its implementation silently drops `hyphens: auto` for any rule that also declares it. Chrome and Firefox don't share this bug.
- Fix: drop `text-wrap: pretty` from the two rules that also hyphenate (`#content`, `.passage` / `section.readings`). `text-wrap: pretty` only affects minor last-line balancing, not layout correctness, so working hyphenation is the better trade.
- A region-qualified `lang="en-US"` was tried as a possible fix along the way but proved unnecessary once `text-wrap: pretty` was removed — `base.html` is unchanged.

## Test plan
- [x] Verified in Safari 26.6.2: hyphenation now appears in scripture reading paragraphs (tested via a static snapshot of the live page, and confirmed the mechanism via Web Inspector by toggling `text-wrap: pretty` on/off)
- [x] Confirmed no other CSS rule references `text-wrap: pretty` alongside hyphenation
- [ ] Spot-check Chrome/Firefox rendering still looks correct (no functional dependency on `text-wrap: pretty`, purely cosmetic loss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3