### PR TITLE
Use Google's prebuilt Firebase builder image in Cloud Build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -60,19 +60,25 @@ steps:
         # its own CDN edge and never looks for these, so they'd just be dead
         # weight in the deploy.
         find public/media \( -name '*.br' -o -name '*.gz' -o -name '*.zstd' \) -delete
+  # Google's prebuilt Firebase builder image already has firebase-tools
+  # installed, so this skips the npm install a plain node image would need
+  # on every build: https://docs.cloud.google.com/build/docs/deploying-builds/deploy-firebase
+  #
   # Auth is implicit via the Cloud Build service account's
   # roles/firebasehosting.admin IAM binding (Application Default
   # Credentials, auto-detected from Cloud Build's metadata server) -- no
-  # token or key needed here.
+  # token or key needed here. Google's docs for this builder image also
+  # mention Firebase Admin and API Keys Viewer roles, but that's broader
+  # guidance for firebase-tools generally -- this only ever runs
+  # `deploy --only hosting`, which is the same command (and same required
+  # permissions) as before, just invoked from a different container.
   - id: FirebaseDeploy
-    name: node:20
-    entrypoint: bash
+    name: us-docker.pkg.dev/firebase-cli/us/firebase
     args:
-      - -c
-      - |
-        set -e
-        npm install -g firebase-tools@15
-        firebase deploy --only hosting --project $PROJECT_ID --non-interactive
+      - deploy
+      - --only=hosting
+      - --project=$PROJECT_ID
+      - --non-interactive
 images:
   - $_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA
 options:


### PR DESCRIPTION
## Summary
- `FirebaseDeploy` was installing `firebase-tools` via `npm install -g` on a plain `node:20` image on every single build. Switches to Google's prebuilt builder image (`us-docker.pkg.dev/firebase-cli/us/firebase`), which already has `firebase-tools` installed -- skips that install step entirely, should speed up the build.
- Reference: https://docs.cloud.google.com/build/docs/deploying-builds/deploy-firebase

## IAM check
Checked the actual IAM policy on the GCP project (`orthocal-1d1b9`) before making this change: the Cloud Build service account (`289038393582@cloudbuild.gserviceaccount.com`) has exactly `roles/firebasehosting.admin`, which is what makes today's `firebase deploy --only hosting` work. This change doesn't alter the deploy command or its scope (still `--only hosting`), just which container invokes it, so that existing permission should carry over. Google's docs for this builder image also mention Firebase Admin / API Keys Viewer roles, but that reads as general guidance for `firebase-tools` usage broadly, not a strict requirement for hosting-only deploys specifically.

## Test plan
- [x] Validated the resulting `cloudbuild.yaml` as valid YAML
- [x] Confirmed current IAM bindings via `gcloud projects get-iam-policy`
- [ ] Watch the first real Cloud Build run after merge to confirm `FirebaseDeploy` succeeds -- if it fails with a permissions error, grant the Cloud Build service account the Firebase Admin and/or API Keys Viewer roles per Google's docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3