### PR TITLE
Fix mobile page-nav sizing and print stylesheet regressions

### DIFF
--- a/calendarium/templates/calendar.html
+++ b/calendarium/templates/calendar.html
@@ -28,7 +28,7 @@
 		<div class="toggle-row" hx-params="none">
 			<div class="segmented-control">
 				<label title="OCA, ROCOR"><input type="radio" name="tradition" value="slavic" {% if tradition == "slavic" %}checked=""{% endif %} hx-get="{% url "calendar" tradition="slavic" cal=cal year=this_month.year month=this_month.month %}" hx-select="#orthocal-content" hx-target="#orthocal-content" hx-swap="outerHTML" hx-push-url="true">Slavic</label>
-				<label title="Antiochian, Greek Archdiocese"><input type="radio" name="tradition" value="greek" {% if tradition == "greek" %}checked=""{% endif %} hx-get="{% url "calendar" tradition="greek" cal=cal year=this_month.year month=this_month.month %}" hx-select="#orthocal-content" hx-target="#orthocal-content" hx-swap="outerHTML" hx-push-url="true">Greek<span class="status-badge">New</span></label>
+				<label title="Antiochian, Greek Archdiocese"><input type="radio" name="tradition" value="greek" {% if tradition == "greek" %}checked=""{% endif %} hx-get="{% url "calendar" tradition="greek" cal=cal year=this_month.year month=this_month.month %}" hx-select="#orthocal-content" hx-target="#orthocal-content" hx-swap="outerHTML" hx-push-url="true">Greek</label>
 			</div>
 			<div class="segmented-control">
 				<label><input type="radio" name="calendar" value="gregorian" {% if cal == "gregorian" %}checked=""{% endif %} hx-get="{% url "calendar" tradition=tradition cal="gregorian" year=this_month.year month=this_month.month %}" hx-select="#orthocal-content" hx-target="#orthocal-content" hx-swap="outerHTML" hx-push-url="true">Gregorian</label>

--- a/calendarium/templates/readings.html
+++ b/calendarium/templates/readings.html
@@ -28,7 +28,7 @@
 		<div class="toggle-row" hx-params="none">
 			<div class="segmented-control">
 				<label title="OCA, ROCOR"><input type="radio" name="tradition" value="slavic" {% if tradition == "slavic" %}checked=""{% endif %} hx-get="{% if translation %}{% url "readings" tradition="slavic" cal=cal translation=translation year=date.year month=date.month day=date.day %}{% else %}{% url "readings" tradition="slavic" cal=cal year=date.year month=date.month day=date.day %}{% endif %}" hx-select="#orthocal-content" hx-target="#orthocal-content" hx-swap="outerHTML" hx-push-url="true">Slavic</label>
-				<label title="Antiochian, Greek Archdiocese"><input type="radio" name="tradition" value="greek" {% if tradition == "greek" %}checked=""{% endif %} hx-get="{% if translation %}{% url "readings" tradition="greek" cal=cal translation=translation year=date.year month=date.month day=date.day %}{% else %}{% url "readings" tradition="greek" cal=cal year=date.year month=date.month day=date.day %}{% endif %}" hx-select="#orthocal-content" hx-target="#orthocal-content" hx-swap="outerHTML" hx-push-url="true">Greek<span class="status-badge">New</span></label>
+				<label title="Antiochian, Greek Archdiocese"><input type="radio" name="tradition" value="greek" {% if tradition == "greek" %}checked=""{% endif %} hx-get="{% if translation %}{% url "readings" tradition="greek" cal=cal translation=translation year=date.year month=date.month day=date.day %}{% else %}{% url "readings" tradition="greek" cal=cal year=date.year month=date.month day=date.day %}{% endif %}" hx-select="#orthocal-content" hx-target="#orthocal-content" hx-swap="outerHTML" hx-push-url="true">Greek</label>
 			</div>
 			<div class="segmented-control">
 				<label><input type="radio" name="calendar" value="gregorian" {% if cal == "gregorian" %}checked=""{% endif %} hx-get="{% if translation %}{% url "readings" tradition=tradition cal="gregorian" translation=translation year=date.year month=date.month day=date.day %}{% else %}{% url "readings" tradition=tradition cal="gregorian" year=date.year month=date.month day=date.day %}{% endif %}" hx-select="#orthocal-content" hx-target="#orthocal-content" hx-swap="outerHTML" hx-push-url="true">Gregorian</label>
@@ -105,7 +105,6 @@
 					<option value="{% url "readings" tradition=tradition cal=cal translation=value year=date.year month=date.month day=date.day %}" {% if translation == value %}selected{% endif %}>{{ label }}</option>
 					{% endfor %}
 				</select>
-				<span class="status-badge">New</span>
 			</label>
 		</p>
 		{% endif %}

--- a/orthocal/static/main.css
+++ b/orthocal/static/main.css
@@ -422,7 +422,7 @@ nav.page-nav {
     width: 75%;
     margin: 0 auto;
     padding: 0.4em 0 0.15em 0;
-    font-size: clamp(0.65em, calc(3.2cqw), 1.1em);
+    font-size: clamp(0.8em, calc(3.2cqw), 1.1em);
     font-family: var(--font-sans);
     /* This whole element is destroyed and rebuilt via an htmx OOB swap on
        every readings/calendar navigation. When it's near the top of the
@@ -536,10 +536,18 @@ a.active {
 	vertical-align: middle;
 }
 /* Let the day-nav and toggle row wrap onto two lines at the narrowest
-   viewports, alongside the topbar's own last-resort wrap above. */
+   viewports, alongside the topbar's own last-resort wrap above. Below this
+   breakpoint the two segmented controls alone no longer fit side by side
+   either (see .toggle-row's own flex-wrap here) -- center them as a
+   stacked pair instead of leaving them at flex-end, where a lone
+   wrapped-down control would sit oddly right-aligned under the row above
+   it. */
 @media (max-width: 400px) {
     .day-nav, .toggle-row {
         flex-wrap: wrap;
+    }
+    .toggle-row {
+        justify-content: center;
     }
 }
 

--- a/orthocal/static/main.css
+++ b/orthocal/static/main.css
@@ -679,6 +679,9 @@ section.readings h2 {
     color: var(--color-text-secondary);
 }
 .passage {
+    columns: 3 20em;
+    column-gap: 2em;
+    column-rule: 1px solid var(--color-border-subtle);
     padding-top: 2em;
     widows: 3;
     orphans: 3;

--- a/orthocal/static/main.css
+++ b/orthocal/static/main.css
@@ -473,7 +473,7 @@ a.active {
 	display: flex;
 	justify-content: flex-end;
 	align-items: center;
-	gap: 1rem;
+	gap: 0.5rem;
 	flex-wrap: nowrap;
 }
 .segmented-control {
@@ -488,7 +488,7 @@ a.active {
 	align-items: center;
 	gap: 0.35em;
 	margin: 0;
-	padding: 3px 14px;
+	padding: 3px 9px;
 	color: var(--color-text-tertiary);
 	cursor: pointer;
 	transition-property: background-color, color;
@@ -522,32 +522,14 @@ a.active {
         font-weight: bold;
     }
 }
-.status-badge {
-	display: inline-block;
-	font-size: 0.65em;
-	font-weight: bold;
-	text-transform: uppercase;
-	letter-spacing: 0.05em;
-	color: var(--color-text-on-accent);
-	background-color: var(--color-accent);
-	border-radius: 3px;
-	padding: 1px 5px;
-	margin-left: 2px;
-	vertical-align: middle;
-}
-/* Let the day-nav and toggle row wrap onto two lines at the narrowest
-   viewports, alongside the topbar's own last-resort wrap above. Below this
-   breakpoint the two segmented controls alone no longer fit side by side
-   either (see .toggle-row's own flex-wrap here) -- center them as a
-   stacked pair instead of leaving them at flex-end, where a lone
-   wrapped-down control would sit oddly right-aligned under the row above
-   it. */
+/* Let the day-nav wrap onto its own line at the narrowest viewports,
+   alongside the topbar's own last-resort wrap above, when it no longer
+   fits alongside the toggle row. The toggle row itself (.toggle-row,
+   above) stays nowrap and is sized to always fit on one line down to the
+   narrowest realistic phone width instead of wrapping. */
 @media (max-width: 400px) {
-    .day-nav, .toggle-row {
+    .day-nav {
         flex-wrap: wrap;
-    }
-    .toggle-row {
-        justify-content: center;
     }
 }
 
@@ -601,7 +583,7 @@ main#orthocal iframe {
 #orthocal-content > header h1 {
 	margin-top: 0;
 	color: var(--color-text-secondary);
-	font-size: 1.5em;
+	font-size: clamp(1.1em, calc(4cqw + 12px), 1.5em);
 }
 #orthocal-content > header h1 span {
 	margin-top: 0;

--- a/orthocal/static/print.css
+++ b/orthocal/static/print.css
@@ -35,10 +35,31 @@ table.month tr:first-child th {
 .print-exclude {
     display: none;
 }
+/* The select's own border and native dropdown caret only make sense as an
+   interactive-control affordance -- on paper it's just inert text, so drop
+   both rather than carry them over from the screen styling. */
+.translation-picker select {
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    border: none;
+}
+/* The columns/column-gap themselves are inherited from main.css's .passage
+   rule (restored there too, matching how this worked in June -- print was
+   only ever a thin override on top of a shared screen-authoritative base,
+   not a separate layout). column-rule stays off for print specifically,
+   same as it always did even back when main.css set one for screen. */
 .passage {
+    column-rule: none;
     widows: 2;
     orphans: 2;
-    column-rule: 0;
+}
+/* Bias the page-break engine against starting the readings on page 2 --
+   this is a hint, not a guarantee, but combined with the compact
+   multi-column layout above it should keep the readings under the title
+   on page 1 for all but the longest commemoration lists. */
+.readings-columns {
+    break-before: avoid;
 }
 /* The reddish gradient/shadow band behind the date and day title (main.css's
    #orthocal-content > header::before) is screen-only decoration, added well

--- a/orthocal/static/print.css
+++ b/orthocal/static/print.css
@@ -54,11 +54,20 @@ table.month tr:first-child th {
     widows: 2;
     orphans: 2;
 }
-/* Bias the page-break engine against starting the readings on page 2 --
-   this is a hint, not a guarantee, but combined with the compact
-   multi-column layout above it should keep the readings under the title
-   on page 1 for all but the longest commemoration lists. */
+/* Keep the two sections (Scripture Readings / Commemorations) side by side
+   for print, matching the screen layout. main.css already has a
+   @media (max-width: 800px) that would collapse this to one column, but
+   print engines don't agree on what width that ends up evaluating against
+   for a page box (confirmed: Chrome collapsed it at print, Safari didn't)
+   -- re-assert the side-by-side values here so print doesn't depend on
+   that breakpoint matching (or not) at all. Also bias the page-break
+   engine against starting the readings on page 2 -- a hint, not a
+   guarantee, but combined with the compact multi-column layout above it
+   should keep the readings under the title on page 1 for all but the
+   longest commemoration lists. */
 .readings-columns {
+    grid-template-columns: 1fr 1fr;
+    gap: 3em;
     break-before: avoid;
 }
 /* The reddish gradient/shadow band behind the date and day title (main.css's

--- a/orthocal/static/print.css
+++ b/orthocal/static/print.css
@@ -7,6 +7,11 @@ html {
 body {
     padding: 0;
     margin: 1in 0 0 0;
+    /* The parchment grain texture and page-background gradient (main.css)
+       are screen-only decoration added well after this stylesheet was
+       written -- neither was ever meant to survive to print, and printing
+       them just wastes ink. */
+    background: none;
 }
 .topbar {
     display: none;
@@ -16,7 +21,6 @@ nav.page-nav {
 }
 main#orthocal {
     width: 100%;
-    border-top: 0;
     margin: 0;
     padding: 0;
 }
@@ -36,10 +40,14 @@ table.month tr:first-child th {
     orphans: 2;
     column-rule: 0;
 }
-.readings-columns {
-    border-top: 0;
+/* The reddish gradient/shadow band behind the date and day title (main.css's
+   #orthocal-content > header::before) is screen-only decoration, added well
+   after this stylesheet was written -- same reasoning as body's background
+   above. */
+#orthocal-content > header::before {
+    display: none;
 }
-main#orthocal > header h1 {
+#orthocal-content > header h1 {
 	font-size: 200%;
 }
 h1, h2, h3, h4 {


### PR DESCRIPTION
## Summary

### Mobile page-nav
Three mobile issues, all traced to `nav.page-nav`'s sizing rules:

1. **Day-nav text too small to read**: raised the `font-size: clamp()` floor from 13px to 16px.
2. **Segmented controls wrapping onto separate lines**: not a regression (confirmed byte-identical to the pre-session baseline). Removed the three "New" status badges entirely (live a couple weeks now, largest single contributor to the toggle row's width), tightened gap/padding -- toggle row now stays on one line down to 320px instead of wrapping.
3. **Date heading not scaling on mobile**: gave the date its own `clamp()` instead of a flat `1.5em` -- unchanged at desktop widths, scales down at narrow ones, restores title-bigger-than-date hierarchy at every width.

### Print stylesheet
Compared `print.css`/`main.css` against the commit current on June 18 to find what actually regressed since the redesign, then iterated live with Brian against real Safari/Chrome/Firefox print output:

- `body`'s grain-texture background and `#orthocal-content > header::before`'s gradient/shadow band are screen-only additions from the redesign that never got a print reset -- were bleeding into print output. Both reset/hidden for print.
- The print-only 200% date-heading boost had gone silently dead (stale selector after the `#orthocal-content` wrapper landed in #204). Fixed.
- Two now-fully-dead border-zeroing rules removed (borders they targeted don't exist anymore -- the redesign uses grid gap for spacing instead).
- **Side-by-side sections forced for print, always**: `.readings-columns`'s collapse-to-one-column behavior depends on `@media (max-width: 800px)`, and print engines don't agree on what width that evaluates against for a page box (Chrome collapsed it, Safari didn't). Re-asserted the side-by-side grid values directly in print.css so it doesn't depend on that breakpoint at all -- Brian's explicit call to match the screen layout for print.
- **Multi-column passage text flow tried, then dropped entirely**: initially restored June's `.passage { columns: 3 20em; ... }` (screen and print both), but once the side-by-side section split was locked in, Brian decided the outer split was columns enough -- the nested per-section multi-column flow was removed from both screen and print as unnecessary.
- **Firefox print-pagination investigation, closed out as a known/accepted limitation**: Brian found the readings starting on page 2 instead of under the title in Firefox specifically. Tried `break-before`/`page-break-before: avoid`, trimming the header's print padding for real headroom, and removing the nested multi-column fragmentation context -- none of it changed Firefox's behavior. Conclusion, confirmed by process of elimination: Firefox treats the `.readings-columns` grid as atomic for print pagination (fits entirely on the page, or moves entirely to the next one), and the day's full readings/stories content is essentially always taller than one page, so it always moves. Chrome and Safari don't have this limitation. Brian's decision: accept it rather than give up the side-by-side layout (declined both alternatives -- CSS multicol instead of grid, or single-column stacking -- to keep it matching the screen).
- **Translation `<select>`**: removed its border and native dropdown caret for print only (`appearance: none`) -- inert on paper. Screen is untouched.

## Verification
- Mobile nav: verified across 320-1400px via a same-origin iframe with an independent CSS viewport (window resize doesn't affect the actual rendering viewport in this dev environment).
- Print: verified via a cache-busted static snapshot of the live rendered page with `print.css`'s media forced to apply normally, checked via `getComputedStyle` (grid columns, background resets, select stripping).
- The Firefox pagination gap specifically was diagnosed via Brian's own real Safari/Chrome/Firefox testing across several iterations -- not something the forced-media simulation could reproduce, since print-engine page-fragmentation behavior isn't fully observable outside real print rendering.
- Full test suite: `docker compose run --rm tests` -- 162 tests, all passing (re-run after every round of changes).

## Test plan
- [x] Mobile nav verified across 320-1400px via iframe
- [x] Print output verified via forced-media static snapshot + computed-style checks
- [x] Full test suite passes
- [x] Real-browser print testing (Safari, Chrome, Firefox) across multiple iterations -- surfaced and resolved the side-by-side inconsistency; surfaced and knowingly accepted the Firefox pagination gap
- [ ] Final spot-check on a real phone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3