### PR TITLE
Shorten the Douay-Rheims translation dropdown label

### DIFF
--- a/calendarium/datetools.py
+++ b/calendarium/datetools.py
@@ -47,7 +47,7 @@ def translation_session_key(language):
 TRANSLATION_LABELS = {
     'kjv': 'King James Version',
     'lxx2012-web': 'LXX2012 & WEB',
-    'douay-rheims': 'Douay-Rheims (Challoner, 1899)',
+    'douay-rheims': 'Douay-Rheims',
     'rccv': 'Romanian Corrected Cornilescu Version',
     'srp1865': 'Serbian (Karadžić/Daničić, 1865)',
 }


### PR DESCRIPTION
## Summary
- Drops "(Challoner, 1899)" from the Douay-Rheims dropdown label so it matches the plain style of the other entries (e.g. "King James Version"). The historical detail stays in the About page's fuller description, added separately in #209.

(Note: this was originally pushed as a follow-up commit to #209, but that PR had already been merged by the time it landed, so it never made it to main. Recovering it here as its own small PR.)

## Test plan
- [x] Full suite passes (`docker compose run --rm tests`)
- [x] Verified via curl that the dropdown now shows "Douay-Rheims" instead of "Douay-Rheims (Challoner, 1899)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3