### PR TITLE
Fix scripture reference wrapping on narrow viewports

### DIFF
--- a/calendarium/templates/readings.html
+++ b/calendarium/templates/readings.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load fullurl %}
+{% load scripture_extras %}
 
 {% block title %}{% if request.resolver_match.url_name == "index" %}Orthodox Daily Scripture Readings and Lives of the Saints{% else %}Orthodox Daily Readings for {{ day.gregorian_date|date:"F j, Y" }}{% endif %}{% endblock %}
 
@@ -68,8 +69,8 @@
 				{% for reading in day.readings %}
 				<li>
 					<a href="#reading-{{ reading.id }}">
-						{{ reading.pericope.display }}
-						({{ reading.source }}{% if reading.desc %}, {{ reading.desc }}{% endif %})
+						{{ reading.pericope.display|keep_numeral_with_book }}
+						<span class="ref-source">({{ reading.source }}{% if reading.desc %}, {{ reading.desc }}{% endif %})</span>
 					</a>
 				</li>
 				{% endfor %}
@@ -113,7 +114,7 @@
 		{% for reading in day.readings %}
 		<article class="passage" id="reading-{{ reading.id }}">
 			<h2>
-				{{ reading.pericope.display }}
+				{{ reading.pericope.display|keep_numeral_with_book }}
 				({{ reading.source }}{% if reading.desc %}, {{ reading.desc }}{% endif %})
 			</h2>
 

--- a/calendarium/templatetags/scripture_extras.py
+++ b/calendarium/templatetags/scripture_extras.py
@@ -1,0 +1,15 @@
+import re
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def keep_numeral_with_book(value):
+    """Bible references starting with a numeral (e.g. "1 Corinthians",
+    "2 Kings") read badly if a line wraps right after that numeral,
+    leaving it dangling alone -- joins it to the next word with a
+    non-breaking space so only the reference's other spaces stay
+    wrappable."""
+    return re.sub(r'^(\d+)\s+', '\\1\N{NO-BREAK SPACE}', str(value), count=1)

--- a/calendarium/tests/test_templatetags.py
+++ b/calendarium/tests/test_templatetags.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+
+from ..templatetags.scripture_extras import keep_numeral_with_book
+
+
+class KeepNumeralWithBookTestCase(TestCase):
+    def test_joins_leading_numeral_to_book_name(self):
+        self.assertEqual(
+            '1\N{NO-BREAK SPACE}Corinthians 15.1-11',
+            keep_numeral_with_book('1 Corinthians 15.1-11'),
+        )
+
+    def test_only_replaces_the_leading_space(self):
+        """Only the space right after the numeral is non-breaking --
+        everything else in the reference should stay normally wrappable."""
+        result = keep_numeral_with_book('2 Thessalonians 1.1-2.2')
+        self.assertEqual('2\N{NO-BREAK SPACE}Thessalonians 1.1-2.2', result)
+        self.assertIn(' ', result)
+
+    def test_leaves_references_without_a_leading_numeral_unchanged(self):
+        self.assertEqual('Mark 3.13-21', keep_numeral_with_book('Mark 3.13-21'))

--- a/orthocal/static/main.css
+++ b/orthocal/static/main.css
@@ -843,7 +843,15 @@ label {
 	color: inherit;
 	text-decoration: none;
 }
-.scripture-list li a {
+/* The reference itself (e.g. "2 Corinthians 7.10-16") can wrap freely at
+   its own spaces -- nowrap here previously forced the entire reference
+   *and* its "(Source, Desc)" suffix onto one unbreakable line, which on a
+   narrow phone (main#orthocal's 75% width leaves very little room) simply
+   overflowed rather than wrapping anywhere. Only the short parenthetical
+   suffix stays glued together now, so the line can still break between it
+   and the reference, or within the reference, without ever breaking
+   inside "(Gospel, Thaddaeus)" itself. */
+.scripture-list li a .ref-source {
 	white-space: nowrap;
 }
 .commemorations li a:hover, .scripture-list li a:hover {


### PR DESCRIPTION
## Summary
- `.scripture-list li a` had `white-space: nowrap`, forcing the whole reference plus its "(Source, Desc)" suffix onto one unbreakable line. Since `main#orthocal` is a fixed 75% width with no mobile override, the usable column on a phone is much narrower than the viewport -- confirmed via direct measurement that "Mark 3.13-21 (Gospel, Thaddaeus)" (267px) overflows a 240px effective width (a 320px-wide phone) entirely, spilling off both edges instead of wrapping.
- Removed the blanket `nowrap` and scoped it to just the parenthetical suffix (now its own `<span class="ref-source">`), so a line can break between the reference and the suffix, or within the reference itself.
- That surfaced a second issue on retest: an unqualified break within the reference could land right after a Bible book's leading numeral (e.g. "1 Corinthians" breaking into "1" / "Corinthians"). Added a `keep_numeral_with_book` template filter that joins a leading numeral to the next word with a non-breaking space, so only the reference's other spaces stay wrappable.

## Test plan
- [x] Full suite passes (`docker compose run --rm tests`), 168/168 (3 new filter tests)
- [x] Verified via a constrained-width DOM clone that references no longer overflow at realistic narrow-phone widths (240px effective width for a 320px viewport)
- [x] Verified "1 Corinthians 15.1-11" and similar numbered-book references stay glued together even at an extreme 170px width, wrapping between the book name and the chapter/verse instead
- [x] Verified normal desktop rendering is unaffected (still one line, as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3