### PR TITLE
Merge duplicate Aug 24 saint: Hieromartyr Eutychius/Eutyches

### DIFF
--- a/docs/saint-dedup-2026-08.md
+++ b/docs/saint-dedup-2026-08.md
@@ -106,3 +106,17 @@ Three of the day-native-vs-additive merges (Basil of Amasea, Mark of Arethusa, E
 ## Status
 
 Stopped here per explicit direction (spot-check + targeted scan rather than a full literal 366-date read) after 9 confirmed merges across 5 independent techniques, with strong convergent evidence the easily-findable duplicates are now cleared. Branch `saint-dedup-2026-08`, PR #157 open.
+
+## Correction #2 (2026-08-24): Hieromartyr Eutychius/Eutyches was a real duplicate after all
+
+Flagged by Brian on the live Aug 24 page. Both this pass (line 71/95 above) and the original saint-model-refactor's Stage 2 had left "Hieromartyr Eutychius" (Saint 5366, day-native, no story) and "Hieromartyr Eutyches (1st c.)" (Saint 5892, additive, full story) unmerged -- but on inspection, the Stage 2 finding those citations actually rest on was about something else entirely: Stage 2 severed an *incorrect* `alt_title` link that had conflated "Eutyches (1st c.)" with **Patriarch Eutychius of Constantinople** (d. 582, feast April 6 -- see `docs/saint-model-refactor.md` line 201). That's a real, different, well-documented person -- but he isn't who's actually sitting on Aug 24 in this data, and nothing here was ever re-checked against a live external source before this pass re-cited the old finding as if it settled *this* pairing too.
+
+Checked against two independent live sources:
+- **OCA's calendar** (oca.org/saints/lives) lists exactly one such saint for Aug 24: "Hieromartyr Eutyches," disciple of Sts John the Theologian and Paul, from Sebastea -- matching Saint 5892's story almost verbatim.
+- **Wikipedia's "August 24 (Eastern Orthodox liturgics)"** compilation lists exactly one such saint for the same date, same biography (disciple of John the Theologian, imprisonment/tortures, peaceful death) -- but spells it **"Hieromartyr Eutychius"**, matching Saint 5366's name instead.
+
+Two independent calendars, one person, two transliterations -- and Patriarch Eutychius's actual date (April 6) rules him out as an explanation for the bare Aug 24 entry. Merged: moved Saint 5892's story onto DayCommemoration 5476 (day-native, kept as canonical per the established pattern), set Saint 5366's `full_name` to "Hieromartyr Eutyches, disciple of St John the Theologian (1st c.)" (trimmed to solo identity per the Correction #1 rule above -- his teachers stay in the story prose, not the identity descriptor), deleted Saint 5892 / DayCommemoration 6022 / the DayCommemorationSaint link row.
+
+168/168 tests pass after the fix; fixture diff confirms only these rows changed.
+
+**Takeaway**: a documented "already checked, left unmerged" conclusion is only as good as what was actually checked at the time -- worth re-verifying against a live source when revisited, not just re-citing the prior note.

--- a/fixtures/commemorations.json
+++ b/fixtures/commemorations.json
@@ -1868,7 +1868,7 @@
   "pk": 5366,
   "fields": {
     "name": "Hieromartyr Eutychius",
-    "full_name": null
+    "full_name": "Hieromartyr Eutyches, disciple of St John the Theologian (1st c.)"
   }
 },
 {
@@ -5717,14 +5717,6 @@
   "fields": {
     "name": "Hieromartyr Pothinos, Bishop of Lyons (177)",
     "full_name": "Hieromartyr Pothinos, Bishop of Lyons (177)"
-  }
-},
-{
-  "model": "commemorations.saint",
-  "pk": 5892,
-  "fields": {
-    "name": "Hieromartyr Eutyches (1st c.)",
-    "full_name": "Hieromartyr Eutyches (1st c.)"
   }
 },
 {
@@ -16998,7 +16990,7 @@
   "fields": {
     "day": 672,
     "title": "Hieromartyr Eutychius",
-    "story": null,
+    "story": "<p>He was a disciple and friend of St John the Theologian, and worked with the Apostle Paul, and is himself named as an Apostle though he is not one of the Seventy. He travelled widely in the ministry of the Gospel of Christ, suffering many imprisonments and tortures. He died in Sebastia, the place of his birth. The <i>Prologue</i> says that he was beheaded, the <i>Great Horologion</i> that he reposed in peace “in deep old age.”</p>",
     "rank": 3,
     "high_rank": false,
     "new_style": false,
@@ -24759,21 +24751,6 @@
     "new_style": false,
     "day_native": false,
     "ordering": 3,
-    "tradition": "common"
-  }
-},
-{
-  "model": "commemorations.daycommemoration",
-  "pk": 6022,
-  "fields": {
-    "day": 672,
-    "title": "Hieromartyr Eutyches (1st c.)",
-    "story": "<p>He was a disciple and friend of St John the Theologian, and worked with the Apostle Paul, and is himself named as an Apostle though he is not one of the Seventy. He travelled widely in the ministry of the Gospel of Christ, suffering many imprisonments and tortures. He died in Sebastia, the place of his birth. The <i>Prologue</i> says that he was beheaded, the <i>Great Horologion</i> that he reposed in peace “in deep old age.”</p>",
-    "rank": 0,
-    "high_rank": false,
-    "new_style": false,
-    "day_native": false,
-    "ordering": 0,
     "tradition": "common"
   }
 },
@@ -46026,15 +46003,6 @@
   "fields": {
     "commemoration": 6021,
     "saint": 5891,
-    "order": 1
-  }
-},
-{
-  "model": "commemorations.daycommemorationsaint",
-  "pk": 773,
-  "fields": {
-    "commemoration": 6022,
-    "saint": 5892,
     "order": 1
   }
 },


### PR DESCRIPTION
## Summary
Brian noticed a duplicate saint on today's (Aug 24) page: "Hieromartyr Eutychius" and "Hieromartyr Eutyches" both listed, and suspected a missed transliteration variant.

Two prior investigations had already looked at this exact pair and left it unmerged -- the original `saint-model-refactor` project's Stage 2, and this doc's own Pass 4 (`docs/saint-dedup-2026-08.md`). Both times cited the same Stage 2 finding, but that finding was actually about something else: severing an *incorrect* `alt_title` link that had conflated "Eutyches (1st c.)" with **Patriarch Eutychius of Constantinople** (a real, different, well-documented person, feast April 6). Neither prior pass re-checked this specific Aug 24 pairing against a live external source.

Checked two independent sources:
- **OCA's calendar**: exactly one such saint for Aug 24 -- "Hieromartyr Eutyches," disciple of Sts John the Theologian and Paul, from Sebastea.
- **Wikipedia's "August 24 (Eastern Orthodox liturgics)"**: exactly one such saint, same biography, spelled **"Hieromartyr Eutychius"** instead.

Same person, two transliterations across two independent calendars -- and Patriarch Eutychius's real feast date (April 6) rules him out as an explanation for the bare Aug 24 entry.

## Changes
- `fixtures/commemorations.json`: moved the additive entry's story onto the day-native `DayCommemoration` (kept canonical, matching the project's established merge pattern), set a solo `full_name` on the canonical `Saint`, deleted the duplicate `Saint`/`DayCommemoration`/link rows.
- `docs/saint-dedup-2026-08.md`: logged the correction and the reasoning, per the doc's existing convention.

## Test plan
- [x] Full suite passes (`docker compose run --rm tests`), 168/168
- [x] Verified via `liturgics.Day(2026, 8, 24, ...)` that Aug 24 now shows exactly one Eutychius entry, with the merged story and full_name
- [x] Confirmed the fixture diff is surgical (2 insertions, 34 deletions -- exactly the merge, no stray reformatting)
- [x] No golden test fixtures reference this date/name, so nothing else needed updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3