### PR TITLE
Correct 4 fast_exception fixes to use the blank index, not 'Strict Fast'

### DIFF
--- a/docs/greek-fasting.md
+++ b/docs/greek-fasting.md
@@ -253,13 +253,13 @@ sources). Corrected all 9 directly from the cached raw JSON:
 
 | Date | antiochian.org | Was | Now |
 |---|---|---|---|
-| Mar 31 | Strict | Wine & Oil (1) | Strict (9) |
+| Mar 31 | Strict | Wine & Oil (1) | Strict (0) |
 | May 7 | No Fast | Fish/Wine/Oil (2) | No Fast (11) |
 | May 11 | No Fast | Fish/Wine/Oil (2) | No Fast (11) |
-| Jul 15 | Strict | Fish/Wine/Oil (2) | Strict (9) |
+| Jul 15 | Strict | Fish/Wine/Oil (2) | Strict (0) |
 | Jul 26 | No Fast | Fish/Wine/Oil (2) | No Fast (11) |
-| Aug 28 | Strict | Wine & Oil (1) | Strict (9) |
-| Sep 25 | Strict | Fish/Wine/Oil (2) | Strict (9) |
+| Aug 28 | Strict | Wine & Oil (1) | Strict (0) |
+| Sep 25 | Strict | Fish/Wine/Oil (2) | Strict (0) |
 | Oct 1 | No Fast | Fish/Wine/Oil (2) | No Fast (11) |
 | Dec 13 | Fish/Wine/Oil | Fish/Wine/Oil (2) | Wine & Oil (1) |
 
@@ -271,3 +271,33 @@ exception has an actual feast-rank basis and wasn't part of this bug.
 **Not investigated further**: whether other `greek`-tradition rows (not
 matching this exact blank-placeholder shape) have similar staleness --
 this pass only searched for the specific pattern that surfaced the bug.
+
+### Correction: the 4 "Strict" dates initially used the wrong index
+
+Brian noticed Aug 28 now displaying an explicit "Strict Fast" label,
+when other ordinary full-abstention Wed/Fri days (e.g. 8/21, 8/26) show
+no label at all for the identical restriction -- only genuinely notable
+strict-fast days (Beheading of John the Baptist, 8/29) get that
+callout. The `DIETARY_ALLOWANCE_TO_FAST_EXCEPTION` table in
+`ingest_antiochian.py` maps `DietaryAllowance.Strict` to
+`fast_exception=9` ("Strict Fast"), and that mapping was used verbatim
+for the Mar 31 / Jul 15 / Aug 28 / Sep 25 fixes above without checking
+it against how the rest of the corpus actually represents an ordinary
+strict day.
+
+`FAST_EXCEPTION_TO_DIETARY_ALLOWANCE` in `datetools.py` shows indices
+0, 9, and 10 all map to the identical `DietaryAllowance.Strict` rung
+(same abstentions either way) -- they're display-text variants for
+different narrative contexts, not different dietary outcomes. Checking
+the DB directly: `fast_exception=9` appeared *nowhere* in the entire
+`greek`-tradition table except these 4 rows just added, while `0`
+(blank, no special text) is the convention used consistently elsewhere,
+including for other full-abstention-but-unremarkable rows ("Forefeast
+of Annunciation", "Wednesday of the Fifth Week of Lent"). Corrected all
+4 from 9 to 0 to match. The other 5 dates (`11`/Fast Free, `1`/Wine and
+Oil) weren't affected by this mistake -- `11` is a code-recognized
+sentinel (`_apply_fasting_adjustments` forces `NoFast` on sight of it)
+and `1` already matched precedent elsewhere.
+
+168/168 tests pass after the correction; fixture diff is exactly these
+4 rows' `fast_exception`, 9 -> 0.

--- a/fixtures/calendarium.json
+++ b/fixtures/calendarium.json
@@ -16914,7 +16914,7 @@
     "service_note": "",
     "story": null,
     "fast": 0,
-    "fast_exception": 9,
+    "fast_exception": 0,
     "flag": 0,
     "tradition": "greek"
   }
@@ -17014,7 +17014,7 @@
     "service_note": "",
     "story": null,
     "fast": 0,
-    "fast_exception": 9,
+    "fast_exception": 0,
     "flag": 0,
     "tradition": "greek"
   }
@@ -17094,7 +17094,7 @@
     "service_note": "",
     "story": null,
     "fast": 0,
-    "fast_exception": 9,
+    "fast_exception": 0,
     "flag": 0,
     "tradition": "greek"
   }
@@ -17114,7 +17114,7 @@
     "service_note": "",
     "story": null,
     "fast": 0,
-    "fast_exception": 9,
+    "fast_exception": 0,
     "flag": 0,
     "tradition": "greek"
   }


### PR DESCRIPTION
## Summary
Follow-up to #215 (already merged), which was correct on the underlying dietary restrictions but wrong about the *label* for 4 of the 9 dates it fixed.

That PR mapped antiochian.org's "Strict" designation to `fast_exception=9` ("Strict Fast"), following `ingest_antiochian.py`'s `DIETARY_ALLOWANCE_TO_FAST_EXCEPTION` table verbatim. Brian noticed Aug 28 now showing an explicit "Strict Fast" label that other identical-restriction ordinary Wed/Fri days (8/21, 8/26) don't show -- that callout is reserved for genuinely notable strict-fast days (Beheading of John the Baptist, 8/29) elsewhere in the data.

`FAST_EXCEPTION_TO_DIETARY_ALLOWANCE` in `datetools.py` shows indices 0, 9, and 10 all map to the identical `Strict` dietary rung -- same abstentions regardless, just different label text for different contexts. Checked the DB directly: `fast_exception=9` appeared nowhere in the entire `greek`-tradition table except the 4 rows #215 just added, while `0` (blank, no special text) is the convention used consistently elsewhere, including for other full-abstention-but-unremarkable rows ("Forefeast of Annunciation", "Wednesday of the Fifth Week of Lent").

Corrected Mar 31 / Jul 15 / Aug 28 / Sep 25 from `fast_exception=9` to `0`. The other 5 dates from #215 (`11`/Fast Free, `1`/Wine and Oil) were unaffected by this mistake -- `11` is a code-recognized sentinel and `1` already matched precedent elsewhere.

(This commit was originally pushed as a follow-up to #215, but that PR had already been merged by the time it landed, so it never made it to main. Recovering it here as its own PR.)

## Test plan
- [x] Full suite passes (`docker compose run --rm tests`), 168/168
- [x] Verified Aug 28 now shows the same blank-label strict fast as 8/21 and 8/26
- [x] Verified Beheading of John the Baptist (8/29) still correctly shows its own distinct label, unaffected
- [x] Confirmed the diff is exactly these 4 `fast_exception` values (9 -> 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3