### PR TITLE
Add cross-document view transitions between separate pages

### DIFF
--- a/orthocal/static/main.css
+++ b/orthocal/static/main.css
@@ -650,8 +650,29 @@ main#orthocal iframe {
    the translation swap alone actually touches) so a nested element is
    never independently named while its ancestor also is -- the View
    Transitions spec extracts named elements from their ancestor's capture,
-   which would otherwise split one swap into two competing transitions. */
+   which would otherwise split one swap into two competing transitions.
+
+   @view-transition (navigation: auto) extends the same mechanism to full
+   navigations between separate pages (Readings -> Calendar -> About,
+   etc. -- plain <a> links, not htmx) in browsers that support
+   cross-document view transitions; unsupported browsers just keep doing
+   an ordinary instant navigation, so this is pure progressive
+   enhancement. Every page shares this same #orthocal-content wrapper
+   (base.html), and the spec matches same-named elements across the
+   outgoing/incoming document pair automatically, so no per-page markup
+   is needed -- only the topbar differs in a way worth calling out: its
+   own content is nearly always identical between two page loads (same
+   header, same nav), so it isn't given a name at all and is left inside
+   the (disabled-animation) root group, where an unnamed identical region
+   simply doesn't visibly change. Nested in the same reduced-motion query
+   as the rest of this block -- without that, reduced-motion users would
+   still get the root group's default crossfade on every navigation, since
+   enabling navigation itself and disabling the root's animation are two
+   separate declarations. */
 @media (prefers-reduced-motion: no-preference) {
+    @view-transition {
+        navigation: auto;
+    }
     #orthocal-content {
         view-transition-name: orthocal-content;
     }

--- a/orthocal/static/main.css
+++ b/orthocal/static/main.css
@@ -668,7 +668,14 @@ main#orthocal iframe {
    as the rest of this block -- without that, reduced-motion users would
    still get the root group's default crossfade on every navigation, since
    enabling navigation itself and disabling the root's animation are two
-   separate declarations. */
+   separate declarations.
+
+   Duration/easing pinned explicitly to Chrome's own UA-default values
+   (0.25s ease) rather than left to each browser's default: Safari ships
+   cross-document view transitions too, but with a noticeably shorter
+   default duration, so the same navigation feels abrupt there and
+   unhurried in Chrome. Setting it here makes both engines pace the
+   crossfade identically instead of each reaching for their own default. */
 @media (prefers-reduced-motion: no-preference) {
     @view-transition {
         navigation: auto;
@@ -679,6 +686,12 @@ main#orthocal iframe {
     ::view-transition-old(root),
     ::view-transition-new(root) {
         animation: none;
+    }
+    ::view-transition-group(orthocal-content),
+    ::view-transition-old(orthocal-content),
+    ::view-transition-new(orthocal-content) {
+        animation-duration: 0.25s;
+        animation-timing-function: ease;
     }
 }
 #orthocal-content > header {


### PR DESCRIPTION
## Summary
- Opts into the View Transitions API's cross-document mode (`@view-transition { navigation: auto }`) so full navigations between separate pages (Readings -> Calendar -> Saints -> About, etc. -- plain `<a>` links, not htmx) crossfade in browsers that support it, falling back to an ordinary instant navigation everywhere else.
- Every page shares the same `#orthocal-content` wrapper (`base.html`) that already carries a `view-transition-name` from the earlier htmx-swap work, and the spec matches same-named elements across the outgoing/incoming document pair automatically -- no per-page markup needed. The topbar is deliberately left unnamed (its content is nearly always identical between page loads) and stays inside the already-disabled root group.
- Explicitly pins the crossfade's duration/easing to Chrome's own UA-default values (`0.25s ease`) rather than leaving it to each browser's default -- Safari ships this feature too, but with a noticeably shorter default duration, making the same navigation feel abrupt there and unhurried in Chrome. Pinning it keeps Chrome's look unchanged while bringing Safari in line.
- All of this is nested behind `prefers-reduced-motion: no-preference`, consistent with the rest of the view-transition setup on this site.

Firefox hasn't shipped cross-document view transitions yet, so it correctly falls back to an ordinary instant navigation -- not a bug, just the expected progressive-enhancement fallback.

## Test plan
- [x] Full suite passes (`docker compose run --rm tests`), 168/168
- [x] Confirmed the `@view-transition` rule parses correctly even nested inside the `prefers-reduced-motion` media query, and that `'ViewTransition' in window` is true in Chrome
- [x] Manually verified by Brian across real browsers: works well in Chrome, correctly falls back to instant navigation in Firefox, and (after the duration fix) now paces consistently with Chrome in Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3