### PR TITLE
Render LXX2012's plural-you marker as a legible superscript

### DIFF
--- a/bible/tests/test_parse.py
+++ b/bible/tests/test_parse.py
@@ -29,3 +29,14 @@ class ParseTest(TestCase):
         verse = Verse.objects.get(book='JHN', chapter=1, verse=1, language='en', translation='douay-rheims')
         self.assertEqual(expected, verse.content)
         self.assertNotIn('G3056', verse.content)
+
+    def test_lxx2012_plural_you_marker_preserved(self):
+        """LXX2012's source file documents (in its own front matter) that
+        U+2303 (UP ARROWHEAD) glued onto "you"/"You" is a deliberate mark
+        for 2nd-person *plural* ("ye"), not a stray artifact -- modern
+        English has no distinct plural "you". parse_usfx() must preserve
+        it in stored content; rendering it legibly is a template-layer
+        concern (see scripture_extras.mark_plural_you)."""
+        expected = 'And if you⌃ be willing, and listen to me, you⌃ shall eat the good of the land:'
+        verse = Verse.objects.get(book='ISA', chapter=1, verse=19, language='en', translation='lxx2012-web')
+        self.assertEqual(expected, verse.content)

--- a/calendarium/templates/readings.html
+++ b/calendarium/templates/readings.html
@@ -121,7 +121,7 @@
 			<p>
 			{% for verse in reading.pericope.passage %}
 				{% if verse.paragraph_start and not forloop.first %}</p><p>{% endif %}
-				<span class="verse-number">{{ verse.verse }}</span>{{ verse.content }}
+				<span class="verse-number">{{ verse.verse }}</span>{{ verse.content|mark_plural_you }}
 			{% endfor %}
 			</p>
 		</article>

--- a/calendarium/templatetags/scripture_extras.py
+++ b/calendarium/templatetags/scripture_extras.py
@@ -1,6 +1,8 @@
 import re
 
 from django import template
+from django.utils.html import escape
+from django.utils.safestring import mark_safe
 
 register = template.Library()
 
@@ -13,3 +15,24 @@ def keep_numeral_with_book(value):
     non-breaking space so only the reference's other spaces stay
     wrappable."""
     return re.sub(r'^(\d+)\s+', '\\1\N{NO-BREAK SPACE}', str(value), count=1)
+
+
+PLURAL_YOU_MARKER = '\N{UP ARROWHEAD}'
+
+
+@register.filter
+def mark_plural_you(value):
+    """LXX2012's own front matter documents that it marks 2nd-person
+    *plural* "you" (translating "ye") with a trailing U+2303 (UP
+    ARROWHEAD) -- modern English has no distinct plural "you", and this
+    is the translator's deliberate substitute, not a stray artifact. The
+    bare glyph reads as a rendering bug to anyone who doesn't already
+    know the convention, so render it as a small, legible superscript
+    instead. Escapes first so only our own hardcoded replacement HTML is
+    ever trusted -- the source text itself never contains markup."""
+    escaped = escape(str(value))
+    marked = escaped.replace(
+        PLURAL_YOU_MARKER,
+        '<sup class="plural-you" title="plural &ldquo;you&rdquo; (translates &ldquo;ye&rdquo;)">pl</sup>',
+    )
+    return mark_safe(marked)

--- a/orthocal/static/main.css
+++ b/orthocal/static/main.css
@@ -840,6 +840,14 @@ section.readings h2 {
     color: var(--color-text-faint);
     margin-right: 1px;
 }
+/* LXX2012's plural-"you" marker (see scripture_extras.mark_plural_you) --
+   styled like .verse-number above (small, faint, superscript) so it
+   reads as the same family of unobtrusive annotation, not a typo. */
+.passage p .plural-you {
+    font-size: 0.7em;
+    color: var(--color-text-faint);
+    cursor: help;
+}
 .day>p {
     text-align: center;
 }


### PR DESCRIPTION
## Summary
Brian reported "caret-like artifacts" throughout the March 16, 2027 Old Testament readings. Traced to U+2303 (UP ARROWHEAD) glued onto "you"/"You" in `data/eng-lxx2012_usfx.xml` -- initially assumed to be a stray editorial leftover and fixed by stripping it, but Brian caught that the file's own front matter documents it as deliberate:

> "Because modern English lacks a distinct 2nd person plural pronoun that is universally accepted, we have translated "ye" as "you^". This is like "you-all", "y'all", "you lot", "yeunz", "you guys"..."

So it's not a bug -- it's the translator's substitute for the real singular/plural distinction the KJV's thou/ye used to carry, which modern English lost. Blindly stripping it would have quietly destroyed that information rather than fixed anything.

## Approach
- `bible/parse.py` is untouched -- the marker stays in stored `Verse.content` as a data-fidelity matter, and survives even if the source file is ever re-downloaded from the supplier (an earlier version of this fix hand-edited the XML file directly, which Brian flagged as fragile for exactly that reason).
- Added a `mark_plural_you` template filter (`calendarium/templatetags/scripture_extras.py`) that escapes the verse content first (so only our own hardcoded replacement HTML is ever trusted) and substitutes the marker with a small superscript `pl`, with a hover title explaining it, styled to match the site's existing `.verse-number` convention so it reads as intentional annotation rather than a rendering glitch.
- Applied only in `readings.html`'s passage rendering -- the API/JSON output is untouched, so API consumers still get the raw source character as plain text (appropriate there; HTML markup wouldn't belong in a JSON string).

## Test plan
- [x] Full suite passes (`docker compose run --rm tests`), 169/169
- [x] Verified via `parse_usfx()` directly against the (still-pristine) source file that the marker survives parsing unchanged
- [x] Verified visually in-browser: renders as a clean, small "pl" superscript next to "you", matching the existing verse-number style
- [x] Confirmed the source XML file has zero diff (never hand-edited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf6j2xXQXywHVh3HAVRxB3