### PR TITLE
Greek lectionary: Aug 28 is Slavic-only, oca.org cross-check, and the commit #220 dropped

### DIFF
--- a/calendarium/tests/test_liturgics.py
+++ b/calendarium/tests/test_liturgics.py
@@ -1672,3 +1672,46 @@ class TestOrdoJurisdictionLabels(TestCase):
         displays = [d for d, _ in await self.gospels(2021, 1, 19, Tradition.Slavic)]
         self.assertNotIn('Matt 22.1-14', displays)
         self.assertNotIn('Matt 19.16-26', displays)
+
+
+class TestAug28JobOfPochaev(TestCase):
+    """Aug 28's vigil set is Slavic only.
+
+    Job of Pochaev is a 17th-century Ukrainian saint kept in the Russian
+    church, and the day carries a full vigil package -- Vespers Old Testament
+    lessons, a Matins Gospel, and a proper Epistle and Gospel. It had been
+    tagged `common`, so Greek was being served a saint it does not commemorate.
+
+    Settled against the sources rather than by inference, which is why it sat
+    open for a while (see PR #217): antiochian.org shows only the ordinary
+    daily cycle on Aug 28 in 8 of 8 harvested years, never naming a
+    commemoration in the day's title, and goarch.org agrees for 2026. That is
+    meaningful rather than merely absent evidence, because the same feed
+    demonstrably *does* surface a saint's proper readings when one applies --
+    that is how most of the Greek Menaion data in this project was found.
+    """
+
+    fixtures = ['calendarium.json', 'commemorations.json']
+
+    JOB_SET = ['Wis 3.1-9', 'Wis 5.15-6.3', 'Wis 4.7-15',
+               'Matt 11.27-30', 'Gal 5.22-6.2', 'Luke 6.17-23']
+
+    async def readings(self, tradition):
+        pday = liturgics.Day(2026, 8, 28, tradition=tradition)
+        await pday.ainitialize()
+        return [r.pericope.sdisplay for r in await pday.aget_readings()]
+
+    async def test_slavic_keeps_the_whole_vigil_set(self):
+        found = await self.readings(Tradition.Slavic)
+        for reading in self.JOB_SET:
+            self.assertIn(reading, found)
+
+    async def test_greek_gets_none_of_it(self):
+        found = await self.readings(Tradition.Greek)
+        for reading in self.JOB_SET:
+            self.assertNotIn(reading, found)
+
+    async def test_greek_still_gets_the_daily_cycle(self):
+        # Removing the vigil set must not leave the day empty.
+        self.assertEqual(await self.readings(Tradition.Greek),
+                         ['2 Cor 11.5-21', 'Mark 4.1-9'])

--- a/data/antiochian_raw/2020-01-19.json
+++ b/data/antiochian_raw/2020-01-19.json
@@ -1,0 +1,20 @@
+{
+  "feastDayTitle": "12TH SUNDAY OF LUKE",
+  "feastDayTeaser": "12th Sunday of Luke,Macarius the Great of Egypt,Mark, Bishop of Ephesus,Arsenius of Corfu,Makarios of Alexandria,Makarios,\u2026.",
+  "feastDayDescription": "12th Sunday of Luke,Macarius the Great of Egypt,Mark, Bishop of Ephesus,Arsenius of Corfu,Makarios of Alexandria,Makarios, Hierodeacon of Kalogera, Patmos,Removal of the Honorable Relics of Saint Gregory the Theologian,Branwallader, Bishop of Jersey",
+  "reading1Title": "ST. PAUL'S LETTER TO THE COLOSSIANS 3:4-11",
+  "reading1Teaser": "Brethren, when Christ who is our life appears, then you also will appear with him in glory. Put to death therefore what is earthly in you: fornication, impurity, passion, evil desire, and covetousness,...",
+  "reading1FullText": "Brethren, when Christ who is our life appears, then you also will appear with him in glory. Put to death therefore what is earthly in you: fornication, impurity, passion, evil desire, and covetousness, which is idolatry. On account of these the wrath of God is coming upon the sons of disobedience. In these you once walked, when you lived in them. But now put them all away: anger, wrath, malice, slander, and foul talk from your mouth. Do not lie to one another, seeing that you have put off the old nature with its practices and have put on the new nature, which is being renewed in knowledge after the image of its creator. Here there cannot be Greek and Jew, circumcised and uncircumcised, barbarian, Scythian, slave, free man, but Christ is all, and in all.",
+  "reading2Title": "LUKE 17:12-19",
+  "reading2Teaser": "At that time, as Jesus entered a village, he was met by ten lepers, who stood at a distance and lifted up their voices and said:  \"Jesus, Master, have mercy on us.\"  When he saw them he said to them, \"Go and show yourselves to the priests.\" And as they went they were cleansed.  Then one of them,...",
+  "reading2FullText": "At that time, as Jesus entered a village, he was met by ten lepers, who stood at a distance and lifted up their voices and said:  \"Jesus, Master, have mercy on us.\"  When he saw them he said to them, \"Go and show yourselves to the priests.\" And as they went they were cleansed.  Then one of them, when he saw that he was healed, turned back, praising God with a loud voice; and he fell on his face at Jesus's feet, giving him thanks.  Now he was a Samaritan.  Then said Jesus: \"Were not ten cleansed? Where are the nine?  Was no one found to return and give praise to God except this foreigner?\" And he said to him: \"Rise and go your way; your faith has made you well.\"",
+  "fastDesignation": "NO FAST",
+  "dailyIcon": "http://farm5.staticflickr.com/4554/37793723365_bb7181db01.jpg",
+  "calendarDateShort": "JANUARY 19, 2020",
+  "calendarDateLong": "SUNDAY, JANUARY 19, 2020",
+  "originalCalendarDate": "2020-01-19",
+  "itemId": 2245,
+  "reading3FullText": "",
+  "reading3Teaser": "",
+  "reading3Title": ""
+}

--- a/data/antiochian_raw/2020-01-24.json
+++ b/data/antiochian_raw/2020-01-24.json
@@ -1,0 +1,20 @@
+{
+  "feastDayTitle": "FRIDAY OF THE 15TH WEEK",
+  "feastDayTeaser": "Xenia, Deaconess of Rome,Vavylas the Holy Martyr,Xenia of St. Petersburg, Fool-for-Christ,Philo the Wonderworker,\u2026.",
+  "feastDayDescription": "Xenia, Deaconess of Rome,Vavylas the Holy Martyr,Xenia of St. Petersburg, Fool-for-Christ,Philo the Wonderworker, Bishop of Karpasia in Cyprus",
+  "reading1Title": "ST. PAUL'S LETTER TO THE GALATIANS 5:22-26; 6:1-2",
+  "reading1Teaser": "Brethren, the fruit of the Spirit is love, joy, peace, patience, kindness, goodness, faithfulness, gentleness, self-control; against such there is no law.  And those who belong to Christ Jesus have crucified the flesh with its passions and desires.  If we live by the Spirit,...",
+  "reading1FullText": "Brethren, the fruit of the Spirit is love, joy, peace, patience, kindness, goodness, faithfulness, gentleness, self-control; against such there is no law.  And those who belong to Christ Jesus have crucified the flesh with its passions and desires.  If we live by the Spirit, let us also walk by the Spirit.  Let us have no self-conceit, no provoking of one another, no envy of one another.  Brethren, if a man is overtaken in any trespass, you who are spiritual should restore him in a spirit of gentleness.  Look to yourself, lest you too be tempted.  Bear one another's burdens, and so fulfill the law of Christ.",
+  "reading2Title": "MARK 12:1-12",
+  "reading2Teaser": "The Lord said this parable, \"A man planted a vineyard, and set a hedge around it, and dug a pit for the wine press, and built a tower, and let it out to tenants, and went into another country. When the time came,...",
+  "reading2FullText": "The Lord said this parable, &quot;A man planted a vineyard, and set a hedge around it, and dug a pit for the wine press, and built a tower, and let it out to tenants, and went into another country. When the time came, he sent a servant to the tenants, to get from them some of the fruit of the vineyard. And they took him and beat him, and sent him away empty handed. Again he sent to them another servant, and they wounded him in the head, and treated him shamefully. And he sent another, and him they killed; and so with many others, some they beat and some they killed. He had still one other, a beloved son; finally he sent him to them, saying, &#39;They will respect my son.&#39; But those tenants said to one another, &#39;This is the heir; come, let us kill him, and the inheritance will be ours.&#39; And they took him and killed him, and cast him out of the vineyard. What will the owner of the vineyard do? He will come and destroy the tenants, and give the vineyard to others. Have you not read this scripture: &#39;The very stone which the builders rejected has become the head of the corner; this was the Lord&#39;s doing, and it is marvelous in our eyes&#39;?&quot; And they tried to arrest him, but feared the multitude, for they perceived that he had told the parable against them; so they left him and went away.\n\n",
+  "fastDesignation": "ABSTAIN FROM MEAT, FISH, DAIRY, EGGS, WINE, OLIVE OIL",
+  "dailyIcon": "http://farm5.staticflickr.com/4554/37793723365_bb7181db01.jpg",
+  "calendarDateShort": "JANUARY 24, 2020",
+  "calendarDateLong": "FRIDAY, JANUARY 24, 2020",
+  "originalCalendarDate": "2020-01-24",
+  "itemId": 2250,
+  "reading3FullText": "",
+  "reading3Teaser": "",
+  "reading3Title": ""
+}

--- a/data/antiochian_raw/2020-01-26.json
+++ b/data/antiochian_raw/2020-01-26.json
@@ -1,0 +1,20 @@
+{
+  "feastDayTitle": "15TH SUNDAY OF LUKE",
+  "feastDayTeaser": "15th Sunday of Luke,Xenophon & his Companions,Symeon the Elder of Mount Sinai.",
+  "feastDayDescription": "15th Sunday of Luke,Xenophon & his Companions,Symeon the Elder of Mount Sinai",
+  "reading1Title": "ST. PAUL'S FIRST LETTER TO TIMOTHY 4:9-15",
+  "reading1Teaser": "Timothy, my son, the saying is sure and worthy of full acceptance. For to this end we toil and suffer reproach, because we have our hope set on the living God, who is the Savior of all men, especially of those who believe. Command and teach these things. Let no one despise your youth,...",
+  "reading1FullText": "Timothy, my son, the saying is sure and worthy of full acceptance. For to this end we toil and suffer reproach, because we have our hope set on the living God, who is the Savior of all men, especially of those who believe. Command and teach these things. Let no one despise your youth, but set the believers an example in speech and conduct, in love, in faith, in purity. Till I come, attend to the public reading of scripture, to preaching, to teaching. Do not neglect the gift you have, which was given you by prophetic utterance when the council of elders laid their hands upon you. Practice these duties, devote yourself to them, so that all may see your progress.",
+  "reading2Title": "LUKE 19:1-10",
+  "reading2Teaser": "At that time, Jesus was passing through Jericho. And there was a man named Zacchaios; he was a chief collector, and rich. And he sought to see who Jesus was, but could not, on account of the crowd, because he was small of stature. So he ran on ahead and climbed up into a sycamore tree to see him,...",
+  "reading2FullText": "At that time, Jesus was passing through Jericho. And there was a man named Zacchaios; he was a chief collector, and rich. And he sought to see who Jesus was, but could not, on account of the crowd, because he was small of stature. So he ran on ahead and climbed up into a sycamore tree to see him, for he was to pass that way. And when Jesus came to the place, he looked up and said to him, \"Zacchaios, make haste and come down; for I must stay at your house today.\" So he made haste and came down, and received him joyfully. And when they saw it they all murmured, \"He has gone in to be the guest of a man who is a sinner.\" And Zacchaios stood and said to the Lord, \"Behold, Lord, the half of my goods I give to the poor; and if I have defrauded any one of anything, I restore it fourfold.\" And Jesus said to him, \"Today salvation has come to this house, since he also is a son of Abraham. For the Son of man came to seek and to save the lost.\"",
+  "fastDesignation": "NO FAST",
+  "dailyIcon": "http://farm5.staticflickr.com/4554/37793723365_bb7181db01.jpg",
+  "calendarDateShort": "JANUARY 26, 2020",
+  "calendarDateLong": "SUNDAY, JANUARY 26, 2020",
+  "originalCalendarDate": "2020-01-26",
+  "itemId": 2252,
+  "reading3FullText": "",
+  "reading3Teaser": "",
+  "reading3Title": ""
+}

--- a/docs/greek-lectionary.md
+++ b/docs/greek-lectionary.md
@@ -204,6 +204,23 @@ A JSON feed, ingested by `ingest_antiochian.py` into `data/antiochian_raw/`
   and it is what made the weekday cycle tractable. It is hidden whenever a
   ranking commemoration claims the day.
 
+## oca.org
+
+The source this project's `common`/`slavic` data was originally compiled from,
+and the one to check before assuming a reading is Greek-specific.
+
+- Daily: `https://www.oca.org/readings/daily/YYYY/MM/DD`
+- A whole year at once: `https://www.oca.org/readings/monthly/YYYY`
+
+Plainly fetchable -- no API, no bot blocking. It lists everything for the day,
+Vespers and Matins included, so a saint's proper readings are distinguishable
+from the daily cycle by what else is present. Lives of the saints are at
+`/saints/lives`.
+
+Note that a commemoration appearing on the page does not mean it has proper
+readings: oca.org lists the Appearance of the Cross on May 7 and the Myrtle
+Tree icon on Sep 24, and gives neither a Liturgy reading.
+
 ## goarch.org
 
 No API, and Cloudflare blocks scripted access -- `requests`, `curl` and
@@ -2043,6 +2060,47 @@ was never observed.
 
 This also puts the 18 Antiochian rows to work. They had been stored but unread
 since the Antiochian tradition was removed.
+
+### Cross-checked against oca.org: the ten Menaion rows are correctly `greek`
+
+The ten Menaion readings added above were scoped `greek` because no OCA source
+was available at the time to say whether Slavic keeps them too. oca.org's daily
+readings turn out to be plainly fetchable at
+`https://www.oca.org/readings/daily/YYYY/MM/DD` (and a whole year at
+`/readings/monthly/YYYY`), so the question was settled directly.
+
+**Nine of the ten are correctly `greek`.** On each date oca.org either gives a
+different reading or none at all:
+
+| date | Greek reads | OCA reads |
+|---|---|---|
+| Apr 25, Mark the Apostle | `Luke 10:16-21` | `Mark 6:7-13` |
+| Apr 30, James the Apostle | `Luke 9:1-6` | `Luke 5:1-11` |
+| May 7 | `Acts 26:1-5, 12-20` | `Gal 1:11-19` / `John 10:1-9`, for St Alexis Toth |
+| Jul 5, Athanasius of Athos (Gospel) | `Matt 11:27-30` at Liturgy | `Luke 6:17-23` at Liturgy, `Matt 11:27-30` at Matins |
+| Jul 13, Synaxis of Gabriel | `Heb 2:2-10` | daily cycle only |
+| Aug 31, Placing of the Sash (both) | `Heb 9:1-7` / `Luke 10:38-42, 11:27-28` | daily cycle only |
+| Sep 24 | `Luke 10:38-42, 11:27-28` | daily cycle only |
+| Dec 17, Daniel and the Three Youths | `Heb 11:33-12:2` | daily cycle only |
+
+May 7 and Sep 24 are worth noting: oca.org *does* list the commemoration --
+the Appearance of the Cross, and an icon called "THE MYRTLE TREE", which is
+Myrtidiotissa -- but assigns it no proper reading. Commemorating a saint and
+giving them a Liturgy reading are separate things, and only the second one
+matters here.
+
+**The tenth is shared but should still stay as two rows.** Both traditions read
+`Gal 5:22-26; 6:1-2` on Jul 5, so a single `common` row looks tempting. It
+would be wrong: the two carry different attributions, and both are accurate.
+Slavic's says *"either Saint"*, because OCA commemorates Athanasius **and** the
+uncovering of the relics of Sergius of Radonezh that day and the Epistle serves
+either; Greek's names Athanasius. Merging would force one tradition's
+attribution on the other.
+
+**Incidental confirmation**: on all eight dates the app's *Slavic* output
+matches oca.org exactly, including the Vespers and Matins readings. That is the
+first direct check of the Slavic data against its own source anywhere in this
+document.
 
 ### Aug 28's vigil set is Slavic only (resolves the open question in PR #217)
 

--- a/docs/greek-lectionary.md
+++ b/docs/greek-lectionary.md
@@ -203,6 +203,13 @@ A JSON feed, ingested by `ingest_antiochian.py` into `data/antiochian_raw/`
   `"TUESDAY OF THE 15TH WEEK"` (Luke section). This is Greek's own numbering
   and it is what made the weekday cycle tractable. It is hidden whenever a
   ranking commemoration claims the day.
+- **A linked service PDF may belong to the *next* day.** Great Vespers is
+  served the evening before, so the file is cross-linked from both dates. Aug
+  28 links a "Great Vespers" text that is actually Aug 29's Beheading of John
+  the Baptist -- the same file is linked from Aug 29's own page, alongside that
+  day's Festal Orthros and Liturgy variables. A vigil-looking service linked
+  from a page is not evidence that *that* day carries a vigil. Read the
+  citations, not the attachments.
 
 ## oca.org
 
@@ -2107,10 +2114,13 @@ document.
 Aug 28 carried a full vigil package tagged `common` -- three Vespers Old
 Testament lessons, a Matins Gospel, and a proper Epistle and Gospel -- for
 **Job of Pochaev**, a 17th-century Ukrainian saint kept in the Russian church.
-Greek was therefore being served a saint it does not commemorate. PR #217
-logged this as an open question in August 2026 and deliberately left the data
-alone: the evidence available then was inconclusive, and this project does not
-change reading data on inference.
+Greek was therefore being served a saint it does not commemorate. This was
+logged as an open question in August 2026 (PR #217, closed unmerged in favour
+of this section) and the data was deliberately left alone: the evidence
+available then was inconclusive, and this project does not change reading data
+on inference. The misreading that made it look inconclusive is now recorded as
+a source trap in Part II -- the "Great Vespers" text linked from Aug 28 is
+Aug 29's.
 
 It is now settled:
 

--- a/docs/greek-lectionary.md
+++ b/docs/greek-lectionary.md
@@ -181,8 +181,13 @@ API. Everything here was learned the hard way; each trap below cost real time.
 A JSON feed, ingested by `ingest_antiochian.py` into `data/antiochian_raw/`
 (currently ~1500 days, 2018-2026).
 
-- **Horizon: 2018 through roughly one year ahead.** 2015-2017 and earlier fail
-  consistently; so does anything much beyond a year out. Several questions in
+- **Horizon: 2018 through the end of the current published year.** 2015-2017
+  and earlier fail consistently. Forward, the limit is not really a horizon:
+  their liturgical chart is published a year at a time, and dates past the end
+  of the current chart return **HTTP 500** because the ordo does not exist yet
+  rather than because the API refuses to reach them. As of August 2026 the
+  chart runs to the end of 2026, and January 2027 returns 500. Re-harvest once
+  the next chart is out rather than concluding the dates are unreachable. Several questions in
   Part III were closed as "permanently unobservable" on this basis --
   **reconsider all of them against goarch.org**, which has no such limit.
 - **Isolated single-date gaps exist** inside the reachable window (2021-01-01

--- a/docs/greek-lectionary.md
+++ b/docs/greek-lectionary.md
@@ -2043,3 +2043,35 @@ was never observed.
 
 This also puts the 18 Antiochian rows to work. They had been stored but unread
 since the Antiochian tradition was removed.
+
+### Aug 28's vigil set is Slavic only (resolves the open question in PR #217)
+
+Aug 28 carried a full vigil package tagged `common` -- three Vespers Old
+Testament lessons, a Matins Gospel, and a proper Epistle and Gospel -- for
+**Job of Pochaev**, a 17th-century Ukrainian saint kept in the Russian church.
+Greek was therefore being served a saint it does not commemorate. PR #217
+logged this as an open question in August 2026 and deliberately left the data
+alone: the evidence available then was inconclusive, and this project does not
+change reading data on inference.
+
+It is now settled:
+
+- **antiochian.org shows only the ordinary daily cycle on Aug 28 in 8 of 8
+  harvested years** (2019-2026), and the day's title is always the plain cycle
+  label -- "13th Friday after Pentecost" and so on. No year names a
+  commemoration, and none carries the `Gal 5:22-26; 6:1-2` / `Luke 6:17-23`
+  pair.
+- **goarch.org agrees** for 2026: `2 Cor 11:5-21` / `Mark 4:1-9`.
+- **oca.org confirms the set is right for Slavic**, listing Job of Pochaev
+  along with all eight readings.
+
+The absence is meaningful rather than merely uninformative, which is what the
+earlier pass could not establish. The same antiochian.org feed demonstrably
+*does* surface a saint's proper readings when one applies -- that is how most
+of the Greek Menaion data in this document was found, and on Jul 5 the very
+same `Gal 5:22-26; 6:1-2` shows up for Athanasius of Athos. A feed that reports
+saint readings reliably, reporting none here across eight years, is evidence.
+
+The six rows are retagged `common` -> `slavic`. Slavic is unchanged; Greek now
+shows the daily cycle alone. `TestAug28JobOfPochaev` covers both, including
+that removing the set does not leave the day empty.

--- a/fixtures/calendarium.json
+++ b/fixtures/calendarium.json
@@ -61641,7 +61641,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 60,
+  "pk": 119,
   "fields": {
     "jurisdiction": "greek",
     "year": 2011,
@@ -61654,7 +61654,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 61,
+  "pk": 120,
   "fields": {
     "jurisdiction": "greek",
     "year": 2011,
@@ -61667,7 +61667,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 62,
+  "pk": 121,
   "fields": {
     "jurisdiction": "greek",
     "year": 2011,
@@ -61680,7 +61680,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 63,
+  "pk": 122,
   "fields": {
     "jurisdiction": "greek",
     "year": 2012,
@@ -61693,7 +61693,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 64,
+  "pk": 123,
   "fields": {
     "jurisdiction": "greek",
     "year": 2012,
@@ -61706,7 +61706,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 65,
+  "pk": 124,
   "fields": {
     "jurisdiction": "greek",
     "year": 2012,
@@ -61719,7 +61719,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 66,
+  "pk": 125,
   "fields": {
     "jurisdiction": "greek",
     "year": 2013,
@@ -61732,7 +61732,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 67,
+  "pk": 126,
   "fields": {
     "jurisdiction": "greek",
     "year": 2013,
@@ -61745,7 +61745,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 68,
+  "pk": 127,
   "fields": {
     "jurisdiction": "greek",
     "year": 2014,
@@ -61758,7 +61758,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 69,
+  "pk": 128,
   "fields": {
     "jurisdiction": "greek",
     "year": 2015,
@@ -61771,7 +61771,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 70,
+  "pk": 129,
   "fields": {
     "jurisdiction": "greek",
     "year": 2015,
@@ -61784,7 +61784,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 71,
+  "pk": 130,
   "fields": {
     "jurisdiction": "greek",
     "year": 2015,
@@ -61797,7 +61797,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 72,
+  "pk": 131,
   "fields": {
     "jurisdiction": "greek",
     "year": 2016,
@@ -61810,7 +61810,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 73,
+  "pk": 132,
   "fields": {
     "jurisdiction": "greek",
     "year": 2016,
@@ -61823,7 +61823,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 74,
+  "pk": 133,
   "fields": {
     "jurisdiction": "greek",
     "year": 2017,
@@ -61836,7 +61836,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 75,
+  "pk": 134,
   "fields": {
     "jurisdiction": "greek",
     "year": 2017,
@@ -61849,7 +61849,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 76,
+  "pk": 135,
   "fields": {
     "jurisdiction": "greek",
     "year": 2017,
@@ -61862,7 +61862,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 77,
+  "pk": 136,
   "fields": {
     "jurisdiction": "greek",
     "year": 2018,
@@ -61875,7 +61875,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 78,
+  "pk": 137,
   "fields": {
     "jurisdiction": "greek",
     "year": 2018,
@@ -61888,7 +61888,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 79,
+  "pk": 138,
   "fields": {
     "jurisdiction": "greek",
     "year": 2018,
@@ -61901,7 +61901,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 80,
+  "pk": 139,
   "fields": {
     "jurisdiction": "greek",
     "year": 2019,
@@ -61914,7 +61914,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 81,
+  "pk": 140,
   "fields": {
     "jurisdiction": "greek",
     "year": 2019,
@@ -61927,7 +61927,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 82,
+  "pk": 141,
   "fields": {
     "jurisdiction": "greek",
     "year": 2019,
@@ -61940,7 +61940,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 83,
+  "pk": 142,
   "fields": {
     "jurisdiction": "greek",
     "year": 2020,
@@ -61953,7 +61953,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 84,
+  "pk": 143,
   "fields": {
     "jurisdiction": "greek",
     "year": 2021,
@@ -61966,7 +61966,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 85,
+  "pk": 144,
   "fields": {
     "jurisdiction": "greek",
     "year": 2021,
@@ -61979,7 +61979,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 86,
+  "pk": 145,
   "fields": {
     "jurisdiction": "greek",
     "year": 2022,
@@ -61992,7 +61992,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 87,
+  "pk": 146,
   "fields": {
     "jurisdiction": "greek",
     "year": 2022,
@@ -62005,7 +62005,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 88,
+  "pk": 147,
   "fields": {
     "jurisdiction": "greek",
     "year": 2022,
@@ -62018,7 +62018,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 89,
+  "pk": 148,
   "fields": {
     "jurisdiction": "greek",
     "year": 2023,
@@ -62031,7 +62031,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 90,
+  "pk": 149,
   "fields": {
     "jurisdiction": "greek",
     "year": 2023,
@@ -62044,7 +62044,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 91,
+  "pk": 150,
   "fields": {
     "jurisdiction": "greek",
     "year": 2023,
@@ -62057,7 +62057,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 92,
+  "pk": 151,
   "fields": {
     "jurisdiction": "greek",
     "year": 2024,
@@ -62070,7 +62070,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 93,
+  "pk": 152,
   "fields": {
     "jurisdiction": "greek",
     "year": 2024,
@@ -62083,7 +62083,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 94,
+  "pk": 153,
   "fields": {
     "jurisdiction": "greek",
     "year": 2024,
@@ -62096,7 +62096,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 95,
+  "pk": 154,
   "fields": {
     "jurisdiction": "greek",
     "year": 2025,
@@ -62109,7 +62109,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 96,
+  "pk": 155,
   "fields": {
     "jurisdiction": "greek",
     "year": 2026,
@@ -62122,7 +62122,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 97,
+  "pk": 156,
   "fields": {
     "jurisdiction": "greek",
     "year": 2026,
@@ -62135,7 +62135,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 98,
+  "pk": 157,
   "fields": {
     "jurisdiction": "greek",
     "year": 2026,
@@ -62148,7 +62148,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 99,
+  "pk": 158,
   "fields": {
     "jurisdiction": "greek",
     "year": 2027,
@@ -62161,7 +62161,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 100,
+  "pk": 159,
   "fields": {
     "jurisdiction": "greek",
     "year": 2027,
@@ -62174,7 +62174,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 101,
+  "pk": 160,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2019,
@@ -62187,7 +62187,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 102,
+  "pk": 161,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2019,
@@ -62200,7 +62200,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 103,
+  "pk": 162,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2019,
@@ -62213,7 +62213,20 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 104,
+  "pk": 163,
+  "fields": {
+    "jurisdiction": "antiochian",
+    "year": 2020,
+    "month": 1,
+    "day": 24,
+    "source": "Gospel",
+    "pdist": 166,
+    "note": "antiochian.org: MARK 12:1-12"
+  }
+},
+{
+  "model": "calendarium.ordoreading",
+  "pk": 164,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2021,
@@ -62226,7 +62239,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 105,
+  "pk": 165,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2021,
@@ -62239,7 +62252,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 106,
+  "pk": 166,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2022,
@@ -62252,7 +62265,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 107,
+  "pk": 167,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2022,
@@ -62265,7 +62278,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 108,
+  "pk": 168,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2022,
@@ -62278,7 +62291,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 109,
+  "pk": 169,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2023,
@@ -62291,7 +62304,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 110,
+  "pk": 170,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2023,
@@ -62304,7 +62317,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 111,
+  "pk": 171,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2023,
@@ -62317,7 +62330,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 112,
+  "pk": 172,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2024,
@@ -62330,7 +62343,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 113,
+  "pk": 173,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2024,
@@ -62343,7 +62356,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 114,
+  "pk": 174,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2024,
@@ -62356,7 +62369,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 115,
+  "pk": 175,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2025,
@@ -62369,7 +62382,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 116,
+  "pk": 176,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2026,
@@ -62382,7 +62395,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 117,
+  "pk": 177,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2026,
@@ -62395,7 +62408,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 118,
+  "pk": 178,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2026,

--- a/fixtures/calendarium.json
+++ b/fixtures/calendarium.json
@@ -36356,7 +36356,7 @@
     "pericope": 890,
     "ordering": 604,
     "flag": 0,
-    "tradition": "common"
+    "tradition": "slavic"
   }
 },
 {
@@ -36371,7 +36371,7 @@
     "pericope": 892,
     "ordering": 605,
     "flag": 0,
-    "tradition": "common"
+    "tradition": "slavic"
   }
 },
 {
@@ -36386,7 +36386,7 @@
     "pericope": 891,
     "ordering": 606,
     "flag": 0,
-    "tradition": "common"
+    "tradition": "slavic"
   }
 },
 {
@@ -36401,7 +36401,7 @@
     "pericope": 46,
     "ordering": 721,
     "flag": 0,
-    "tradition": "common"
+    "tradition": "slavic"
   }
 },
 {
@@ -36416,7 +36416,7 @@
     "pericope": 647,
     "ordering": 821,
     "flag": 0,
-    "tradition": "common"
+    "tradition": "slavic"
   }
 },
 {
@@ -36431,7 +36431,7 @@
     "pericope": 227,
     "ordering": 921,
     "flag": 0,
-    "tradition": "common"
+    "tradition": "slavic"
   }
 },
 {

--- a/fixtures/calendarium.json
+++ b/fixtures/calendarium.json
@@ -61641,7 +61641,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 119,
+  "pk": 60,
   "fields": {
     "jurisdiction": "greek",
     "year": 2011,
@@ -61654,7 +61654,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 120,
+  "pk": 61,
   "fields": {
     "jurisdiction": "greek",
     "year": 2011,
@@ -61667,7 +61667,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 121,
+  "pk": 62,
   "fields": {
     "jurisdiction": "greek",
     "year": 2011,
@@ -61680,7 +61680,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 122,
+  "pk": 63,
   "fields": {
     "jurisdiction": "greek",
     "year": 2012,
@@ -61693,7 +61693,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 123,
+  "pk": 64,
   "fields": {
     "jurisdiction": "greek",
     "year": 2012,
@@ -61706,7 +61706,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 124,
+  "pk": 65,
   "fields": {
     "jurisdiction": "greek",
     "year": 2012,
@@ -61719,7 +61719,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 125,
+  "pk": 66,
   "fields": {
     "jurisdiction": "greek",
     "year": 2013,
@@ -61732,7 +61732,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 126,
+  "pk": 67,
   "fields": {
     "jurisdiction": "greek",
     "year": 2013,
@@ -61745,7 +61745,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 127,
+  "pk": 68,
   "fields": {
     "jurisdiction": "greek",
     "year": 2014,
@@ -61758,7 +61758,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 128,
+  "pk": 69,
   "fields": {
     "jurisdiction": "greek",
     "year": 2015,
@@ -61771,7 +61771,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 129,
+  "pk": 70,
   "fields": {
     "jurisdiction": "greek",
     "year": 2015,
@@ -61784,7 +61784,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 130,
+  "pk": 71,
   "fields": {
     "jurisdiction": "greek",
     "year": 2015,
@@ -61797,7 +61797,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 131,
+  "pk": 72,
   "fields": {
     "jurisdiction": "greek",
     "year": 2016,
@@ -61810,7 +61810,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 132,
+  "pk": 73,
   "fields": {
     "jurisdiction": "greek",
     "year": 2016,
@@ -61823,7 +61823,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 133,
+  "pk": 74,
   "fields": {
     "jurisdiction": "greek",
     "year": 2017,
@@ -61836,7 +61836,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 134,
+  "pk": 75,
   "fields": {
     "jurisdiction": "greek",
     "year": 2017,
@@ -61849,7 +61849,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 135,
+  "pk": 76,
   "fields": {
     "jurisdiction": "greek",
     "year": 2017,
@@ -61862,7 +61862,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 136,
+  "pk": 77,
   "fields": {
     "jurisdiction": "greek",
     "year": 2018,
@@ -61875,7 +61875,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 137,
+  "pk": 78,
   "fields": {
     "jurisdiction": "greek",
     "year": 2018,
@@ -61888,7 +61888,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 138,
+  "pk": 79,
   "fields": {
     "jurisdiction": "greek",
     "year": 2018,
@@ -61901,7 +61901,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 139,
+  "pk": 80,
   "fields": {
     "jurisdiction": "greek",
     "year": 2019,
@@ -61914,7 +61914,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 140,
+  "pk": 81,
   "fields": {
     "jurisdiction": "greek",
     "year": 2019,
@@ -61927,7 +61927,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 141,
+  "pk": 82,
   "fields": {
     "jurisdiction": "greek",
     "year": 2019,
@@ -61940,7 +61940,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 142,
+  "pk": 83,
   "fields": {
     "jurisdiction": "greek",
     "year": 2020,
@@ -61953,7 +61953,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 143,
+  "pk": 84,
   "fields": {
     "jurisdiction": "greek",
     "year": 2021,
@@ -61966,7 +61966,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 144,
+  "pk": 85,
   "fields": {
     "jurisdiction": "greek",
     "year": 2021,
@@ -61979,7 +61979,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 145,
+  "pk": 86,
   "fields": {
     "jurisdiction": "greek",
     "year": 2022,
@@ -61992,7 +61992,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 146,
+  "pk": 87,
   "fields": {
     "jurisdiction": "greek",
     "year": 2022,
@@ -62005,7 +62005,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 147,
+  "pk": 88,
   "fields": {
     "jurisdiction": "greek",
     "year": 2022,
@@ -62018,7 +62018,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 148,
+  "pk": 89,
   "fields": {
     "jurisdiction": "greek",
     "year": 2023,
@@ -62031,7 +62031,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 149,
+  "pk": 90,
   "fields": {
     "jurisdiction": "greek",
     "year": 2023,
@@ -62044,7 +62044,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 150,
+  "pk": 91,
   "fields": {
     "jurisdiction": "greek",
     "year": 2023,
@@ -62057,7 +62057,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 151,
+  "pk": 92,
   "fields": {
     "jurisdiction": "greek",
     "year": 2024,
@@ -62070,7 +62070,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 152,
+  "pk": 93,
   "fields": {
     "jurisdiction": "greek",
     "year": 2024,
@@ -62083,7 +62083,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 153,
+  "pk": 94,
   "fields": {
     "jurisdiction": "greek",
     "year": 2024,
@@ -62096,7 +62096,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 154,
+  "pk": 95,
   "fields": {
     "jurisdiction": "greek",
     "year": 2025,
@@ -62109,7 +62109,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 155,
+  "pk": 96,
   "fields": {
     "jurisdiction": "greek",
     "year": 2026,
@@ -62122,7 +62122,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 156,
+  "pk": 97,
   "fields": {
     "jurisdiction": "greek",
     "year": 2026,
@@ -62135,7 +62135,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 157,
+  "pk": 98,
   "fields": {
     "jurisdiction": "greek",
     "year": 2026,
@@ -62148,7 +62148,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 158,
+  "pk": 99,
   "fields": {
     "jurisdiction": "greek",
     "year": 2027,
@@ -62161,7 +62161,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 159,
+  "pk": 100,
   "fields": {
     "jurisdiction": "greek",
     "year": 2027,
@@ -62174,7 +62174,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 160,
+  "pk": 101,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2019,
@@ -62187,7 +62187,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 161,
+  "pk": 102,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2019,
@@ -62200,7 +62200,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 162,
+  "pk": 103,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2019,
@@ -62213,20 +62213,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 163,
-  "fields": {
-    "jurisdiction": "antiochian",
-    "year": 2020,
-    "month": 1,
-    "day": 24,
-    "source": "Gospel",
-    "pdist": 166,
-    "note": "antiochian.org: MARK 12:1-12"
-  }
-},
-{
-  "model": "calendarium.ordoreading",
-  "pk": 164,
+  "pk": 104,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2021,
@@ -62239,7 +62226,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 165,
+  "pk": 105,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2021,
@@ -62252,7 +62239,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 166,
+  "pk": 106,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2022,
@@ -62265,7 +62252,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 167,
+  "pk": 107,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2022,
@@ -62278,7 +62265,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 168,
+  "pk": 108,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2022,
@@ -62291,7 +62278,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 169,
+  "pk": 109,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2023,
@@ -62304,7 +62291,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 170,
+  "pk": 110,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2023,
@@ -62317,7 +62304,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 171,
+  "pk": 111,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2023,
@@ -62330,7 +62317,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 172,
+  "pk": 112,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2024,
@@ -62343,7 +62330,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 173,
+  "pk": 113,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2024,
@@ -62356,7 +62343,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 174,
+  "pk": 114,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2024,
@@ -62369,7 +62356,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 175,
+  "pk": 115,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2025,
@@ -62382,7 +62369,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 176,
+  "pk": 116,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2026,
@@ -62395,7 +62382,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 177,
+  "pk": 117,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2026,
@@ -62408,7 +62395,7 @@
 },
 {
   "model": "calendarium.ordoreading",
-  "pk": 178,
+  "pk": 118,
   "fields": {
     "jurisdiction": "antiochian",
     "year": 2026,
@@ -62417,6 +62404,19 @@
     "source": "Gospel",
     "pdist": 274,
     "note": "antiochian.org: MARK 12:13-17"
+  }
+},
+{
+  "model": "calendarium.ordoreading",
+  "pk": 180,
+  "fields": {
+    "jurisdiction": "antiochian",
+    "year": 2020,
+    "month": 1,
+    "day": 24,
+    "source": "Gospel",
+    "pdist": 166,
+    "note": "antiochian.org: MARK 12:1-12"
   }
 }
 ]

--- a/tools/greek/harvest_dates.py
+++ b/tools/greek/harvest_dates.py
@@ -12,8 +12,8 @@ from ingest_antiochian import Antiochian, CACHE_DIR
 
 # Edit these for whatever dates need filling in. Already-cached dates are
 # skipped, so re-running is cheap and safe.
-TARGETS = [(7, 5), (9, 24)]
-YEARS = range(2019, 2027)
+TARGETS = [(1, 19), (1, 24), (1, 26)]
+YEARS = [2020, 2027]
 
 client = Antiochian(delay=2.0)
 client.authenticate()

--- a/tools/greek/load_ordo.py
+++ b/tools/greek/load_ordo.py
@@ -6,7 +6,10 @@ of what the jurisdiction published, resolved onto pdists that already exist in
 the Reading table.
 
     docker compose exec -T local python tools/greek/load_ordo.py
-    docker compose exec -T local ./manage.py dumpdata calendarium --indent=1 -o fixtures/calendarium.json
+    docker compose exec -T local ./manage.py dumpdata calendarium --indent=2 -o fixtures/calendarium.json
+
+The indent must be 2. The fixture is stored that way, and dumping it at any
+other width reformats all ~62,000 lines, burying the handful that changed.
 """
 import os, sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
@@ -100,14 +103,27 @@ def antiochian_rows():
             continue
         yield ('antiochian', dt.year, 1, dt.day, 'Gospel', pdist, f'antiochian.org: {citation}')
 
-OrdoReading.objects.all().delete()
 made = collections.Counter()
+seen = set()
 for jur, y, m, dd, source, pdist, note in list(goarch_rows()) + list(antiochian_rows()):
     OrdoReading.objects.update_or_create(
         jurisdiction=jur, year=y, month=m, day=dd, source=source,
         defaults={'pdist': pdist, 'note': note},
     )
     made[jur] += 1
+    seen.add((jur, y, m, dd, source))
+
+# Prune what the sources no longer produce, rather than emptying the table up
+# front and rebuilding it. Rebuilding renumbered every pk on every run, so
+# harvesting one new date rewrote all ~120 rows in the fixture diff and hid the
+# one line that actually changed. update_or_create keeps a surviving row's pk.
+stale = [
+    o.pk for o in OrdoReading.objects.all()
+    if (o.jurisdiction, o.year, o.month, o.day, o.source) not in seen
+]
+if stale:
+    OrdoReading.objects.filter(pk__in=stale).delete()
+    print(f'pruned {len(stale)} row(s) the sources no longer produce')
 
 for jur, n in sorted(made.items()):
     yrs = OrdoReading.objects.filter(jurisdiction=jur).order_by('year')


### PR DESCRIPTION
Consolidates #217, #222 and #223 into one branch. Those three are closed in
favour of this; nothing from any of them is lost.

Six commits, each independently meaningful:

| commit | what it does | came from |
|---|---|---|
| Add the 2020 Antiochian ordo rows | re-lands a commit the #220 squash dropped | #223 |
| Aug 28's vigil set is Slavic only | data fix + tests | #223 |
| Cross-check the Greek Menaion rows against oca.org | docs only | #222 |
| Salvage the Great Vespers source trap | docs only | #217 |
| Keep ordo pks stable across loader runs | tooling only | new |
| Regenerate the fixture with main's ordo pks | fixture only | new |

## 1. Re-lands what the #220 squash missed

`main` is currently missing the last commit of #220. Two things were lost:

- the **2020 Antiochian ordo rows** — `2020-01-24` is a fifth date where the
  two jurisdictions genuinely differ (`antiochian pdist=166` vs `greek 147`)
- the doc note recording that antiochian.org returns **HTTP 500 for 2027
  because their chart is not published yet**, not because the API can't reach
  that far. Without this the horizon looks like a hard limit and several
  Part III questions stay wrongly closed.

Worth knowing for next time: because #220 was squash-merged, `git merge-base
--is-ancestor` reports *every* commit from that branch as absent from `main`,
so it cannot tell you what landed. This was found by comparing file contents.

## 2. Aug 28's vigil set is Slavic only

Aug 28 carried a full vigil package tagged `common` — three Vespers OT
lessons, a Matins Gospel, and a proper Epistle/Gospel — for **Job of Pochaev**,
a 17th-century Ukrainian saint kept in the Russian church. Greek was being
served a saint it does not commemorate.

#217 logged this and deliberately left it alone: the evidence then was
inconclusive, and this project does not change reading data on inference. It is
now settled.

| source | Aug 28 |
|---|---|
| antiochian.org | ordinary daily cycle in **8 of 8** years (2019–2026), always titled with the plain cycle label |
| goarch.org | agrees for 2026: `2 Cor 11:5-21` / `Mark 4:1-9` |
| oca.org | confirms the set is right for Slavic |

The absence is evidence rather than merely uninformative, which is what the
earlier pass could not establish. That same feed demonstrably *does* surface a
saint's proper readings when one applies — it is how most of the Greek Menaion
data in the doc was found, and on Jul 5 this very Epistle appears for Athanasius
of Athos.

Six rows retagged `common` → `slavic`. Verified both directions:

```
2026-08-28 slavic: Wis 3.1-9; Wis 5.15-6.3; Wis 4.7-15; Matt 11.27-30;
                   2 Cor 11.5-21; Gal 5.22-6.2 (St Job); Mark 4.1-9;
                   Luke 6.17-23 (St Job)
2026-08-28 greek : 2 Cor 11.5-21; Mark 4.1-9
```

## 3. The ten Menaion rows are correctly `greek`

Scoped `greek` in #220 because no OCA source was to hand. oca.org turns out to
be plainly fetchable, so this is now checked rather than assumed: **nine of ten
are correctly `greek`** — oca.org gives either a different reading (Apr 25,
Apr 30, May 7, Jul 5's Gospel) or none at all (Jul 13, Aug 31, Sep 24, Dec 17).

The tenth is genuinely shared but still stays as two rows: both traditions read
`Gal 5:22-26; 6:1-2` on Jul 5, but the attributions differ and both are right.
Slavic's says *"either Saint"* because OCA also commemorates the uncovering of
Sergius of Radonezh's relics that day; Greek's names Athanasius. Collapsing to
one `common` row would force one tradition's attribution on the other.

Incidentally: on all eight dates the app's **Slavic** output matches oca.org
exactly, Vespers and Matins included — the first direct check of the Slavic
data against its own source anywhere in the doc.

## 4. Salvaged from #217

#217's conclusion is superseded, but one finding in it is durable and was
recorded nowhere else — it is precisely what made the evidence look
inconclusive:

> antiochian.org's Aug 28 page links a "Great Vespers" service text that is
> actually **Aug 29's** Beheading of John the Baptist, served the evening
> before and cross-linked from both dates.

Now a Part II source trap: a vigil-looking service linked from a page is not
evidence that *that* day carries a vigil. Read the citations, not the
attachments.

## 5. Loader no longer renumbers every ordo pk

Noticed while reviewing this branch's own diff: it touched **119 pk lines to
add one row**. `load_ordo.py` emptied `OrdoReading` and rebuilt it on each run,
so every harvest renumbered the table and buried the actual change.

The up-front `delete()` is replaced by a prune of what the sources no longer
produce; `update_or_create` then keeps a surviving row's pk.

The pks were safe to move, which is worth stating explicitly: `OrdoReading` is
the target of **no foreign key** (the schema's only relation is
`Reading.pericope`), and both the runtime lookup and the tests address these
rows by their natural key `(jurisdiction, year, month, day, source)`. This is a
legibility fix, not a correctness one.

Also corrects the docstring's dump command from `--indent=1` to `--indent=2`.
The fixture is stored at 2 and `load_shared_menaion.py` already documented that;
dumping at 1 reformats all ~62,000 lines, which has happened once already.

Verified: load the fixture, re-run the loader, dump — **empty diff**, all 60
rows keeping their pks — and a row the sources no longer produce is still
removed.

## 6. …and the churn already committed is undone

Fixing the loader stops *future* churn but does not undo what was already
committed in #223, so the branch still renumbered every ordo row (main's
`60-118` → `119-178`). Rebuilt on top of main's own pks with the corrected
loader.

The fixture diff against main is now **exactly** the six Aug 28 retags and the
one added ordo row — **1 pk line touched instead of 119**, and the file's
diffstat drops from 143 changed lines to 25. No data changed; 189 tests still
pass.

## Verification

- **189 tests, OK** (1 skipped) — same count as before, no tests dropped
- fixture diff contains exactly the intended changes and nothing else: 6
  `common` → `slavic` retags and 1 added `ordoreading` row, verified line by
  line; `calendarium.reading` row count unchanged at 1807
- both behaviors spot-checked live (above, and `2020-01-24` correctly renders
  both jurisdictions with labels)

## Closes

- #217 — question resolved; its durable finding salvaged above
- #222 — superseded, commit carried over verbatim
- #223 — superseded, both commits carried over verbatim


